### PR TITLE
[docs] Documentation of crypto module

### DIFF
--- a/docs/crypto.rst
+++ b/docs/crypto.rst
@@ -6,51 +6,147 @@ Cryptography
 AES
 --------------
 
-.. autofunction:: malduck.aes.cbc
-.. autofunction:: malduck.aes.ecb
-.. autofunction:: malduck.aes.ctr
+AES (Advanced Encryption Standard) block cipher.
 
-.. autoclass:: malduck.crypto.aes.AES
-    :members:
+Supported modes: CBC, ECB, CTR.
 
-Blowfish
----------
+.. code-block:: python
 
-.. autofunction:: malduck.blowfish
+    from malduck import aes
 
-DES3
---------------
+    key = b'A'*16
+    iv = b'B'*16
+    plaintext = b'data'*16
+    ciphertext = aes.cbc.encrypt(key, iv, plaintext)
 
-.. autofunction:: malduck.des3.cbc
 
-Serpent
---------------
+AES-CBC mode
+~~~~~~~~~~~~
+.. autofunction:: malduck.aes.cbc.encrypt
+.. autofunction:: malduck.aes.cbc.decrypt
 
-.. autofunction:: malduck.serpent
+AES-ECB mode
+~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: malduck.aes.ecb.encrypt
+.. autofunction:: malduck.aes.ecb.decrypt
+
+AES-CTR mode
+~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: malduck.aes.ctr.encrypt
+.. autofunction:: malduck.aes.ctr.decrypt
+
+Blowfish (ECB only)
+-------------------
+
+Blowfish block cipher.
+
+Supported modes: ECB.
+
+.. code-block:: python
+
+    from malduck import blowfish
+
+    key = b'blowfish'
+    plaintext = b'data'*16
+    ciphertext = blowfish.ecb.encrypt(key, plaintext)
+
+
+.. autofunction:: malduck.blowfish.ecb.encrypt
+.. autofunction:: malduck.blowfish.ecb.decrypt
+
+DES/DES3 (CBC only)
+-------------------
+
+Triple DES block cipher.
+
+Fallbacks to single DES for 8 byte keys.
+
+Supported modes: CBC.
+
+.. code-block:: python
+
+    from malduck import des3
+
+    key = b'des3des3'
+    iv = b'3des3des'
+    plaintext = b'data'*16
+    ciphertext = des3.cbc.decrypt(key, plaintext)
+
+.. autofunction:: malduck.des3.cbc.encrypt
+.. autofunction:: malduck.des3.cbc.decrypt
+
+Serpent (CBC only)
+------------------
+
+Serpent block cipher.
+
+Supported modes: CBC
+
+.. code-block:: python
+
+    from malduck import serpent
+
+    key = b'a'*16
+    iv = b'b'*16
+    plaintext = b'data'*16
+    ciphertext = serpent.cbc.encrypt(key, plaintext, iv=iv)
+
+.. autofunction:: malduck.serpent.cbc.encrypt
+.. autofunction:: malduck.serpent.cbc.decrypt
 
 Rabbit
 --------------
+
+Rabbit stream cipher.
+
+.. code-block:: python
+
+    from malduck import rabbit
+
+    key = b'a'*16
+    plaintext = b'data'*16
+    ciphertext = rabbit(key, plaintext)
 
 .. autofunction:: malduck.rabbit
 
 RC4
 --------------
 
+RC4 stream cipher.
+
+.. code-block:: python
+
+    from malduck import rc4
+
+    key = b'a'*16
+    plaintext = b'data'*16
+    ciphertext = rc4(key, plaintext)
+
 .. autofunction:: malduck.rc4
 
-RSA
+XOR
 --------------
+
+XOR "stream cipher".
+
+.. code-block:: python
+
+    from malduck import xor
+
+    key = b'a'*16
+    xored = b'data'*16
+    unxored = xor(key, xor)
+
+.. autofunction:: malduck.xor
+
+RSA (BLOB parser)
+-----------------
 
 .. autoclass:: malduck.rsa
     :members:
 
 .. autoclass:: malduck.crypto.rsa.RSA
     :members:
-
-XOR
---------------
-
-.. autofunction:: malduck.xor
 
 BLOB struct
 -----------

--- a/docs/crypto.rst
+++ b/docs/crypto.rst
@@ -3,6 +3,8 @@ Cryptography
 
 .. automodule:: malduck.crypto
 
+Common cryptography algorithms used in malware.
+
 AES
 --------------
 

--- a/malduck/bits.py
+++ b/malduck/bits.py
@@ -8,6 +8,7 @@ __all__ = ["rol", "ror", "align", "align_down"]
 def rol(value, count, bits=32):
     """
     Bitwise rotate left
+
     :param value: Value to rotate
     :param count: Number of bits to rotate
     :param bits: Bit-length of rotated value (default: 32-bit, DWORD)
@@ -25,6 +26,7 @@ def rol(value, count, bits=32):
 def ror(value, count, bits=32):
     """
     Bitwise rotate right
+
     :param value: Value to rotate
     :param count: Number of bits to rotate
     :param bits: Bit-length of rotated value (default: 32-bit, DWORD)

--- a/malduck/compression/gzip.py
+++ b/malduck/compression/gzip.py
@@ -25,6 +25,7 @@ class Gzip(object):
 
     :param buf: Buffer to decompress
     :type buf: bytes
+    :rtype: bytes
     """
 
     def decompress(self, buf):

--- a/malduck/compression/lznt1.py
+++ b/malduck/compression/lznt1.py
@@ -15,6 +15,7 @@ class Lznt1(object):
 
     :param buf: Buffer to decompress
     :type buf: bytes
+    :rtype: bytes
     """
 
     def decompress(self, buf):

--- a/malduck/crypto/aes.py
+++ b/malduck/crypto/aes.py
@@ -59,10 +59,34 @@ BlobTypes = {
 
 class AesCbc(object):
     def encrypt(self, key, iv, data):
+        """
+        Encrypts buffer using AES algorithm in CBC mode.
+
+        :param key: Cryptographic key (128, 192 or 256 bits)
+        :type key: bytes
+        :param iv: Initialization vector
+        :type iv: bytes
+        :param data: Buffer to be encrypted
+        :type data: bytes
+        :return: Encrypted data
+        :rtype: bytes
+        """
         cipher = AESCipher.new(key, AESCipher.MODE_CBC, iv=iv)
         return cipher.encrypt(data)
 
     def decrypt(self, key, iv, data):
+        """
+        Decrypts buffer using AES algorithm in CBC mode.
+
+        :param key: Cryptographic key (128, 192 or 256 bits)
+        :type key: bytes
+        :param iv: Initialization vector
+        :type iv: bytes
+        :param data: Buffer to be decrypted
+        :type data: bytes
+        :return: Decrypted data
+        :rtype: bytes
+        """
         cipher = AESCipher.new(key, AESCipher.MODE_CBC, iv=iv)
         return cipher.decrypt(data)
 
@@ -76,10 +100,30 @@ class AesCbc(object):
 
 class AesEcb(object):
     def encrypt(self, key, data):
+        """
+        Encrypts buffer using AES algorithm in ECB mode.
+
+        :param key: Cryptographic key (128, 192 or 256 bits)
+        :type key: bytes
+        :param data: Buffer to be encrypted
+        :type data: bytes
+        :return: Encrypted data
+        :rtype: bytes
+        """
         cipher = AESCipher.new(key, AESCipher.MODE_ECB)
         return cipher.encrypt(data)
 
     def decrypt(self, key, data):
+        """
+        Decrypts buffer using AES algorithm in ECB mode.
+
+        :param key: Cryptographic key (128, 192 or 256 bits)
+        :type key: bytes
+        :param data: Buffer to be decrypted
+        :type data: bytes
+        :return: Decrypted data
+        :rtype: bytes
+        """
         cipher = AESCipher.new(key, AESCipher.MODE_ECB)
         return cipher.decrypt(data)
 
@@ -93,10 +137,34 @@ class AesEcb(object):
 
 class AesCtr(object):
     def encrypt(self, key, nonce, data):
+        """
+        Encrypts buffer using AES algorithm in CTR mode.
+
+        :param key: Cryptographic key (128, 192 or 256 bits)
+        :type key: bytes
+        :param nonce: Initial counter value, big-endian encoded
+        :type nonce: bytes
+        :param data: Buffer to be encrypted
+        :type data: bytes
+        :return: Encrypted data
+        :rtype: bytes
+        """
         cipher = AESCipher.new(key, AESCipher.MODE_CTR, nonce=b"", initial_value=nonce)
         return cipher.encrypt(data)
 
     def decrypt(self, key, nonce, data):
+        """
+        Decrypts buffer using AES algorithm in CTR mode.
+
+        :param key: Cryptographic key (128, 192 or 256 bits)
+        :type key: bytes
+        :param nonce: Initial counter value, big-endian encoded
+        :type nonce: bytes
+        :param data: Buffer to be decrypted
+        :type data: bytes
+        :return: Decrypted data
+        :rtype: bytes
+        """
         cipher = AESCipher.new(key, AESCipher.MODE_CTR, nonce=b"", initial_value=nonce)
         return cipher.decrypt(data)
 

--- a/malduck/crypto/blowfish.py
+++ b/malduck/crypto/blowfish.py
@@ -11,10 +11,30 @@ __all__ = ["Blowfish", "blowfish"]
 
 class BlowfishEcb(object):
     def encrypt(self, key, data):
+        """
+        Encrypts buffer using Blowfish algorithm in ECB mode.
+
+        :param key: Cryptographic key (4 to 56 bytes)
+        :type key: bytes
+        :param data: Buffer to be encrypted
+        :type data: bytes
+        :return: Encrypted data
+        :rtype: bytes
+        """
         cipher = BlowfishCipher.new(key, BlowfishCipher.MODE_ECB)
         return cipher.encrypt(data)
 
     def decrypt(self, key, data):
+        """
+        Decrypts buffer using Blowfish algorithm in ECB mode.
+
+        :param key: Cryptographic key (4 to 56 bytes)
+        :type key: bytes
+        :param data: Buffer to be decrypted
+        :type data: bytes
+        :return: Decrypted data
+        :rtype: bytes
+        """
         cipher = BlowfishCipher.new(key, BlowfishCipher.MODE_ECB)
         return cipher.decrypt(data)
 

--- a/malduck/crypto/des3.py
+++ b/malduck/crypto/des3.py
@@ -18,9 +18,33 @@ class Des3Cbc(object):
         return DES3Cipher.new(key, DES3Cipher.MODE_CBC, iv=iv)
 
     def encrypt(self, key, iv, data):
+        """
+        Encrypts buffer using DES/DES3 algorithm in CBC mode.
+
+        :param key: Cryptographic key (8 bytes for single DES, 16 or 24 bytes)
+        :type key: bytes
+        :param iv: Initialization vector
+        :type iv: bytes
+        :param data: Buffer to be encrypted
+        :type data: bytes
+        :return: Encrypted data
+        :rtype: bytes
+        """
         return self._get_cipher(key, iv).encrypt(data)
 
     def decrypt(self, key, iv, data):
+        """
+        Decrypts buffer using DES/DES3 algorithm in CBC mode.
+
+        :param key: Cryptographic key (8 bytes for single DES, 16 or 24 bytes)
+        :type key: bytes
+        :param iv: Initialization vector
+        :type iv: bytes
+        :param data: Buffer to be decrypted
+        :type data: bytes
+        :return: Decrypted data
+        :rtype: bytes
+        """
         return self._get_cipher(key, iv).decrypt(data)
 
     def __call__(self, key, iv, data):

--- a/malduck/crypto/des3.py
+++ b/malduck/crypto/des3.py
@@ -21,7 +21,7 @@ class Des3Cbc(object):
         """
         Encrypts buffer using DES/DES3 algorithm in CBC mode.
 
-        :param key: Cryptographic key (8 bytes for single DES, 16 or 24 bytes)
+        :param key: Cryptographic key (16 or 24 bytes, 8 bytes for single DES)
         :type key: bytes
         :param iv: Initialization vector
         :type iv: bytes
@@ -36,7 +36,7 @@ class Des3Cbc(object):
         """
         Decrypts buffer using DES/DES3 algorithm in CBC mode.
 
-        :param key: Cryptographic key (8 bytes for single DES, 16 or 24 bytes)
+        :param key: Cryptographic key (16 or 24 bytes, 8 bytes for single DES)
         :type key: bytes
         :param iv: Initialization vector
         :type iv: bytes

--- a/malduck/crypto/rabbit.py
+++ b/malduck/crypto/rabbit.py
@@ -146,19 +146,19 @@ class Rabbit(RabbitCipher):
 
 
 class _Rabbit(object):
-    def __call__(self, key, iv, data):
-        """
-        Encrypts/decrypts buffer using Rabbit algorithm
+    """
+    Encrypts/decrypts buffer using Rabbit algorithm
 
-        :param key: Cryptographic key (16 bytes)
-        :type key: bytes
-        :param iv: Initialization vector (8 bytes)
-        :type iv: bytes
-        :param data: Buffer to be encrypted/decrypted
-        :type data: bytes
-        :return: Encrypted/decrypted data
-        :rtype: bytes
-        """
+    :param key: Cryptographic key (16 bytes)
+    :type key: bytes
+    :param iv: Initialization vector (8 bytes)
+    :type iv: bytes
+    :param data: Buffer to be encrypted/decrypted
+    :type data: bytes
+    :return: Encrypted/decrypted data
+    :rtype: bytes
+    """
+    def __call__(self, key, iv, data):
         return RabbitCipher(key, iv).decrypt(data)
 
     def rabbit(self, key, iv, data):

--- a/malduck/crypto/rabbit.py
+++ b/malduck/crypto/rabbit.py
@@ -147,6 +147,18 @@ class Rabbit(RabbitCipher):
 
 class _Rabbit(object):
     def __call__(self, key, iv, data):
+        """
+        Encrypts/decrypts buffer using Rabbit algorithm
+
+        :param key: Cryptographic key (16 bytes)
+        :type key: bytes
+        :param iv: Initialization vector (8 bytes)
+        :type iv: bytes
+        :param data: Buffer to be encrypted/decrypted
+        :type data: bytes
+        :return: Encrypted/decrypted data
+        :rtype: bytes
+        """
         return RabbitCipher(key, iv).decrypt(data)
 
     def rabbit(self, key, iv, data):

--- a/malduck/crypto/rabbit.py
+++ b/malduck/crypto/rabbit.py
@@ -158,6 +158,7 @@ class _Rabbit(object):
     :return: Encrypted/decrypted data
     :rtype: bytes
     """
+
     def __call__(self, key, iv, data):
         return RabbitCipher(key, iv).decrypt(data)
 

--- a/malduck/crypto/rc.py
+++ b/malduck/crypto/rc.py
@@ -13,7 +13,17 @@ ARC4.key_size = range(3, 256 + 1)
 
 class RC4Cipher(object):
     # todo: transform it to single rc4 function
-    def decrypt(self, key, data):
+    def __call__(self, key, data):
+        """
+        Encrypts/decrypts buffer using RC4 algorithm
+
+        :param key: Cryptographic key (from 3 to 256 bytes)
+        :type key: bytes
+        :param data: Buffer to be encrypted/decrypted
+        :type data: bytes
+        :return: Encrypted/decrypted data
+        :rtype: bytes
+        """
         return ARC4.new(key).decrypt(data)
 
     def rc4(self, key, data):
@@ -23,7 +33,7 @@ class RC4Cipher(object):
         )
         return self.decrypt(key, data)
 
-    __call__ = encrypt = decrypt
+    encrypt = decrypt = __call__
 
 
 class RC4(object):

--- a/malduck/crypto/rc.py
+++ b/malduck/crypto/rc.py
@@ -22,6 +22,7 @@ class RC4Cipher(object):
     :return: Encrypted/decrypted data
     :rtype: bytes
     """
+
     # todo: transform it to single rc4 function
     def __call__(self, key, data):
         return ARC4.new(key).decrypt(data)

--- a/malduck/crypto/rc.py
+++ b/malduck/crypto/rc.py
@@ -12,18 +12,18 @@ ARC4.key_size = range(3, 256 + 1)
 
 
 class RC4Cipher(object):
+    """
+    Encrypts/decrypts buffer using RC4 algorithm
+
+    :param key: Cryptographic key (from 3 to 256 bytes)
+    :type key: bytes
+    :param data: Buffer to be encrypted/decrypted
+    :type data: bytes
+    :return: Encrypted/decrypted data
+    :rtype: bytes
+    """
     # todo: transform it to single rc4 function
     def __call__(self, key, data):
-        """
-        Encrypts/decrypts buffer using RC4 algorithm
-
-        :param key: Cryptographic key (from 3 to 256 bytes)
-        :type key: bytes
-        :param data: Buffer to be encrypted/decrypted
-        :type data: bytes
-        :return: Encrypted/decrypted data
-        :rtype: bytes
-        """
         return ARC4.new(key).decrypt(data)
 
     def rc4(self, key, data):

--- a/malduck/crypto/serpent.py
+++ b/malduck/crypto/serpent.py
@@ -7,9 +7,33 @@ __all__ = ["Serpent", "serpent"]
 
 class SerpentCbc(object):
     def encrypt(self, key, data, iv=None):
+        """
+        Encrypts buffer using Serpent algorithm in CBC mode.
+
+        :param key: Cryptographic key (4-32 bytes, must be multiple of four)
+        :type key: bytes
+        :param data: Buffer to be encrypted
+        :type data: bytes
+        :param iv: Initialization vector (defaults to `b"\x00" * 16`)
+        :type iv: bytes, optional
+        :return: Encrypted data
+        :rtype: bytes
+        """
         return serpent_cbc_encrypt(key, data, iv=iv or b"\x00" * 16)
 
     def decrypt(self, key, data, iv=None):
+        """
+        Decrypts buffer using Serpent algorithm in CBC mode.
+
+        :param key: Cryptographic key (4-32 bytes, must be multiple of four)
+        :type key: bytes
+        :param data: Buffer to be decrypted
+        :type data: bytes
+        :param iv: Initialization vector (defaults to `b"\x00" * 16`)
+        :type iv: bytes, optional
+        :return: Decrypted data
+        :rtype: bytes
+        """
         return serpent_cbc_decrypt(key, data, iv=iv or b"\x00" * 16)
 
 

--- a/malduck/crypto/xor.py
+++ b/malduck/crypto/xor.py
@@ -16,6 +16,7 @@ class XOR(object):
     :return: Encrypted/decrypted data
     :rtype: bytes
     """
+
     def __call__(self, key, data):
         if is_integer(key):
             key = int2byte(key)

--- a/malduck/crypto/xor.py
+++ b/malduck/crypto/xor.py
@@ -6,15 +6,16 @@ __all__ = ["xor"]
 
 
 class XOR(object):
-    def decrypt(self, key, data):
+    def __call__(self, key, data):
         """
-        XOR decryption
+        XOR encryption/decryption
 
         :param key: Encryption key
-        :type key: int or bytes
+        :type key: int (single byte) or bytes
         :param data: Buffer containing data to decrypt
         :type data: bytes
-        :return:
+        :return: Encrypted/decrypted data
+        :rtype: bytes
         """
         if is_integer(key):
             key = int2byte(key)
@@ -23,7 +24,7 @@ class XOR(object):
             for a, b in zip(iterbytes_ord(data), cycle(iterbytes_ord(key)))
         )
 
-    __call__ = encrypt = decrypt
+    encrypt = decrypt = __call__
 
 
 xor = XOR()

--- a/malduck/crypto/xor.py
+++ b/malduck/crypto/xor.py
@@ -6,17 +6,17 @@ __all__ = ["xor"]
 
 
 class XOR(object):
-    def __call__(self, key, data):
-        """
-        XOR encryption/decryption
+    """
+    XOR encryption/decryption
 
-        :param key: Encryption key
-        :type key: int (single byte) or bytes
-        :param data: Buffer containing data to decrypt
-        :type data: bytes
-        :return: Encrypted/decrypted data
-        :rtype: bytes
-        """
+    :param key: Encryption key
+    :type key: int (single byte) or bytes
+    :param data: Buffer containing data to decrypt
+    :type data: bytes
+    :return: Encrypted/decrypted data
+    :rtype: bytes
+    """
+    def __call__(self, key, data):
         if is_integer(key):
             key = int2byte(key)
         return b"".join(


### PR DESCRIPTION
- Fixed `malduck.compression` docs a bit
- Added more verbose documentation of `malduck.crypto` algorithms, including only supported forms.

Documentation can be generated by:

```
$ pip install -e .
$ pip install -r docs/requirements.txt
$ cd docs
$ make html
```

HTML files will be contained in `docs/_build/html`.