### PR TITLE
'cryptography' is no longer used by malduck

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click>=7.0
-cryptography>=2.1
 pefile==2019.4.18
 pyelftools
 pycryptodomex>=3.8.2


### PR DESCRIPTION
Current version (master) uses only PyCryptodome