### PR TITLE
Add bigint.unpack and bigint.pack methods

### DIFF
--- a/docs/string.rst
+++ b/docs/string.rst
@@ -56,7 +56,10 @@ Packing/unpacking (p64/p32/p16/p8, u64/u32/u16/u8, bigint)
 .. autofunction:: malduck.p16
 .. autofunction:: malduck.p8
 
-.. autofunction:: malduck.bigint
+.. autofunction:: malduck.bigint.unpack
+.. autofunction:: malduck.bigint.pack
+.. autofunction:: malduck.bigint.unpack_be
+.. autofunction:: malduck.bigint.pack_be
 
 IPv4 inet_ntoa
 ---------------

--- a/malduck/crypto/rsa.py
+++ b/malduck/crypto/rsa.py
@@ -34,7 +34,7 @@ class PublicKeyBlob(BaseBlob):
         if len(n) != self.bitsize // 8:
             return
 
-        self.n = bigint(n, self.bitsize)
+        self.n = bigint.unpack(n)
         return 12 + self.bitsize // 8
 
     def export_key(self):
@@ -58,27 +58,27 @@ class PrivateKeyBlob(PublicKeyBlob):
         if not off:
             return
 
-        self.p1 = bigint(buf.read(self.bitsize // 16), self.bitsize // 2)
+        self.p1 = bigint.unpack(buf.read(self.bitsize // 16))
         if self.p1 is None:
             return
 
-        self.p2 = bigint(buf.read(self.bitsize // 16), self.bitsize // 2)
+        self.p2 = bigint.unpack(buf.read(self.bitsize // 16))
         if self.p2 is None:
             return
 
-        self.exp1 = bigint(buf.read(self.bitsize // 16), self.bitsize // 2)
+        self.exp1 = bigint.unpack(buf.read(self.bitsize // 16))
         if self.exp1 is None:
             return
 
-        self.exp2 = bigint(buf.read(self.bitsize // 16), self.bitsize // 2)
+        self.exp2 = bigint.unpack(buf.read(self.bitsize // 16))
         if self.exp2 is None:
             return
 
-        self.coeff = bigint(buf.read(self.bitsize // 16), self.bitsize // 2)
+        self.coeff = bigint.unpack(buf.read(self.bitsize // 16))
         if self.coeff is None:
             return
 
-        self.d = bigint(buf.read(self.bitsize // 8), self.bitsize)
+        self.d = bigint.unpack(buf.read(self.bitsize // 8))
         if self.d is None:
             return
 

--- a/malduck/string/bin.py
+++ b/malduck/string/bin.py
@@ -57,21 +57,55 @@ __all__ = [
 
 class Bigint:
     def unpack(self, other: bytes) -> int:
+        """
+        Unpacks bigint value from provided buffer with little-endian order
+
+        .. versionadded:: 4.0.0
+            Use bigint.unpack instead of bigint() method
+
+        :param other: Buffer object containing value to unpack
+        :type other: bytes
+        :rtype: int
+        """
         return self.unpack_be(other[::-1])
 
     def pack(self, other: int) -> bytes:
+        """
+        Packs bigint value into bytes with little-endian order
+
+        .. versionadded:: 4.0.0
+            Use bigint.pack instead of bigint() method
+
+        :param other: Value to be packed
+        :type other: int
+        :rtype: bytes
+        """
         return self.pack_be(other)[::-1]
 
     def unpack_be(self, other: bytes) -> int:
+        """
+        Unpacks bigint value from provided buffer with big-endian order
+
+        :param other: Buffer object containing value to unpack
+        :type other: bytes
+        :rtype: int
+        """
         return int(enhex(other), 16)
 
     def pack_be(self, other: int) -> bytes:
+        """
+        Packs bigint value into bytes with big-endian order
+
+        :param other: Value to be packed
+        :type other: int
+        :rtype: bytes
+        """
         return unhex(f"{other:x}")
 
     def __call__(self, s, bitsize):
         warnings.warn(
             "malduck.bigint() is deprecated, use malduck.bigint.unpack/pack methods",
-            DeprecationWarning
+            DeprecationWarning,
         )
         if is_integer(s):
             return Padding.null(unhex("%x" % s)[::-1], bitsize // 8)

--- a/malduck/string/bin.py
+++ b/malduck/string/bin.py
@@ -92,9 +92,7 @@ class Bigint:
         """
         packed = unhex(f"{other:x}")[::-1]
         if size:
-            packed = packed[:size]
-            padding = b"\x00" * (size - len(packed))
-            packed = packed + padding
+            packed = packed[:size].ljust(size, b"\x00")
         return packed
 
     def unpack_be(self, other: bytes, size: Optional[int] = None) -> int:
@@ -128,9 +126,7 @@ class Bigint:
         """
         packed = unhex(f"{other:x}")
         if size:
-            packed = packed[:size]
-            padding = b"\x00" * (size - len(packed))
-            packed = padding + packed
+            packed = packed[:size].rjust(size, b"\x00")
         return packed
 
     def __call__(self, s, bitsize):

--- a/malduck/string/bin.py
+++ b/malduck/string/bin.py
@@ -73,9 +73,7 @@ class Bigint:
         """
         if size:
             if len(other) < size:
-                raise ValueError(
-                    f"Buffer is trimmed: {len(other)} < {size}"
-                )
+                raise ValueError(f"Buffer is trimmed: {len(other)} < {size}")
             other = other[:size]
         return int(enhex(other[::-1]), 16)
 
@@ -111,9 +109,7 @@ class Bigint:
         """
         if size:
             if len(other) < size:
-                raise ValueError(
-                    f"Buffer is trimmed: {len(other)} < {size}"
-                )
+                raise ValueError(f"Buffer is trimmed: {len(other)} < {size}")
             other = other[:size]
         return int(enhex(other), 16)
 

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -115,6 +115,11 @@ def test_bigint():
     assert bigint.unpack_be(b"ABCDE") == 0x4142434445
     assert bigint.pack_be(0x44434241) == b"DCBA"
 
+    assert bigint.unpack(b"ABCDE", 4) == 0x44434241
+    assert bigint.pack(0x44434241, 8) == b"ABCD\x00\x00\x00\x00"
+    assert bigint.unpack_be(b"ABCDE", 4) == 0x41424344
+    assert bigint.pack_be(0x41424344, 8) == b"\x00\x00\x00\x00ABCD"
+
 
 def test_pack():
     assert pack(

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -110,10 +110,10 @@ def test_bin_reverse():
 
 
 def test_bigint():
-    with pytest.raises(ValueError):
-        bigint(b"ABCD", 40)
-    assert bigint(b"ABCDE", 40) == 0x4544434241
-    assert bigint(0x44434241, 40) == b"ABCD\x00"
+    assert bigint.unpack(b"ABCDE") == 0x4544434241
+    assert bigint.pack(0x44434241) == b"ABCD"
+    assert bigint.unpack_be(b"ABCDE") == 0x4142434445
+    assert bigint.pack_be(0x44434241) == b"DCBA"
 
 
 def test_pack():


### PR DESCRIPTION
- Legacy `malduck.bigint` switches between `int` and `bytes` representation which is counter-intuitive and makes scripts more difficult to read
- Deprecated `malduck.bigint` in favor of `malduck.bigint.unpack` and `malduck.bigint.pack` methods
- Added big-endian variants `malduck.bigint.unpack_be` and `malduck.bigint.pack_be`.
- `bitsize` argument is not used in newer variants (is looks to be relevant only for packing, maybe we should implement it only for `pack` methods)
- Added typings and tests

Closes #10 