### PR TITLE
CI: Bumped flake8 to 3.8.3

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8==3.6.0 pytest==5.4.1 black==19.10b0
+        pip install flake8==3.8.3 pytest==5.4.1 black==19.10b0
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
3.6.0 version is pretty outdated and doesn't know how to deal with `if TYPE_CHECKING` used to avoid cyclic references.