### PR TITLE
Typed extractor methods and `@Extractor.rule` decorator support

### DIFF
--- a/malduck/__init__.py
+++ b/malduck/__init__.py
@@ -10,6 +10,8 @@ from .crypto import aes, blowfish, des3, rabbit, rc4, rsa, serpent, xor
 
 from .disasm import disasm, insn
 
+from .extractor import Extractor
+
 from .hash import crc32, md5, sha1, sha224, sha256, sha384, sha512
 
 from .ints import (
@@ -132,6 +134,8 @@ __all__ = [
     # disasm
     "disasm",
     "insn",
+    # extractor
+    "Extractor",
     # hash
     "crc32",
     "md5",

--- a/malduck/extractor/extract_manager.py
+++ b/malduck/extractor/extract_manager.py
@@ -89,10 +89,10 @@ class ExtractorModules:
             if not os.path.exists(modules_path):
                 os.makedirs(modules_path)
         # Load Yara rules
-        self.rules = Yara.from_dir(modules_path)
+        self.rules: Yara = Yara.from_dir(modules_path)
         # Preload modules
         load_modules(modules_path, onerror=self.on_error)
-        self.extractors = Extractor.__subclasses__()
+        self.extractors: List[Type[Extractor]] = Extractor.__subclasses__()
 
     def on_error(self, exc: Exception, module_name: str) -> None:
         """
@@ -231,11 +231,11 @@ class ExtractManager:
             binaries += list(ProcessMemoryPE.load_binaries_from_memory(p))
             binaries += list(ProcessMemoryELF.load_binaries_from_memory(p))
 
-        def fmt_procmem(p):
+        def fmt_procmem(p: ProcessMemory) -> str:
             procmem_type = "IMG" if getattr(p, "is_image", False) else "DMP"
             return f"{p.__class__.__name__}:{procmem_type}:{p.imgbase:x}"
 
-        def extract_config(procmem):
+        def extract_config(procmem: ProcessMemory) -> Optional[str]:
             log.debug("%s - ripping...", fmt_procmem(procmem))
             extractor = ProcmemExtractManager(self)
             matches.remap(procmem.p2v)
@@ -245,6 +245,7 @@ class ExtractManager:
                 return self.push_config(extractor.family, extractor.config)
             else:
                 log.debug("%s - No luck.", fmt_procmem(procmem))
+            return None
 
         # 'list()' for prettier logs
         log.debug("Matched rules: %s", list(matches.keys()))

--- a/malduck/extractor/extract_manager.py
+++ b/malduck/extractor/extract_manager.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, List, Type, Union
 
 from ..yara import Yara, YaraMatches
 from ..procmem import ProcessMemory
-from .extractor import Extractor, ExtractorBase
+from .extractor import Extractor
 from .loaders import load_modules
 
 log = logging.getLogger(__name__)
@@ -319,7 +319,7 @@ class ProcmemExtractManager:
                     except Exception as exc:
                         self.parent.on_error(exc, extractor)
 
-    def push_config(self, config: Config, extractor: ExtractorBase) -> None:
+    def push_config(self, config: Config, extractor: Extractor) -> None:
         """
         Pushes new partial config
 

--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -46,7 +46,7 @@ class ExtractorMethod:
 
 
 class StringExtractorMethod(ExtractorMethod):
-    def __init__(self, method, string_name=None) -> None:
+    def __init__(self, method, string_name=None):
         super().__init__(method)
         self.string_name = string_name or method.__name__
 
@@ -294,7 +294,7 @@ class Extractor:
     family = None  #: Extracted malware family, automatically added to "family" key for strong extraction methods
     overrides = []  #: Family match overrides another match e.g. citadel overrides zeus
 
-    def __init__(self, parent) -> None:
+    def __init__(self, parent):
         self.parent = parent
 
     def push_procmem(self, procmem: ProcessMemory, **info):

--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import logging
 
 from ..procmem import ProcessMemory, ProcessMemoryPE, ProcessMemoryELF
@@ -356,7 +357,9 @@ class Extractor:
     def _get_methods(self, method_type):
         return (
             (name, method)
-            for name, method in self.__class__.__dict__.items()
+            for name, method in inspect.getmembers(
+                self.__class__, predicate=lambda member: isinstance(member, method_type)
+            )
             if isinstance(method, method_type)
         )
 
@@ -427,7 +430,7 @@ class Extractor:
         elif isinstance(string_or_method, str):
 
             def extractor_wrapper(method):
-                if isinstance(string_or_method, ExtractorMethod):
+                if isinstance(method, ExtractorMethod):
                     raise TypeError("@extractor decorator must be first")
                 return StringExtractorMethod(method, string_name=string_or_method)
 
@@ -444,7 +447,7 @@ class Extractor:
         elif isinstance(string_or_method, str):
 
             def extractor_wrapper(method):
-                if isinstance(string_or_method, ExtractorMethod):
+                if isinstance(method, ExtractorMethod):
                     raise TypeError("@rule decorator must be first")
                 return RuleExtractorMethod(method, rule_name=string_or_method)
 

--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -1,51 +1,11 @@
 import functools
 import logging
 
-from typing import Any, Callable, Dict, List, Union, Tuple, TYPE_CHECKING
-
 from ..procmem import ProcessMemory, ProcessMemoryPE, ProcessMemoryELF
-from ..yara import YaraMatches
-
-if TYPE_CHECKING:
-    from .extract_manager import ProcmemExtractManager
 
 log = logging.getLogger(__name__)
 
 __all__ = ["Extractor"]
-
-Config = Dict[str, Any]
-
-
-class MetaExtractor(type):
-    """
-    Metaclass for Extractor. Handles proper registration of decorated extraction methods
-    """
-
-    def __new__(cls, name, bases, attrs):
-        """
-        Collect ext_yara_string and ext_final methods
-        """
-        klass = type.__new__(cls, name, bases, attrs)
-
-        klass.extractor_methods = dict(getattr(klass, "extractor_methods", {}))
-        klass.final_methods = list(getattr(klass, "final_methods", []))
-
-        if type(getattr(klass, "yara_rules")) not in (list, tuple):
-            raise TypeError(f"'yara_rules' field must be 'list' or 'tuple' in {name}")
-
-        for name, method in attrs.items():
-            if isinstance(method, ExtractorMethod):
-                if method.final:
-                    klass.final_methods.append(name)
-                else:
-                    if method.yara_string in klass.extractor_methods:
-                        raise TypeError(
-                            "There can be only one extractor method "
-                            f'for "{method.yara_string}" string'
-                        )
-                    klass.extractor_methods[method.yara_string] = name
-
-        return klass
 
 
 class ExtractorMethod:
@@ -53,17 +13,24 @@ class ExtractorMethod:
     Represents registered extractor method
     """
 
-    def __init__(self, method: Callable[..., Union[Config, bool, None]]) -> None:
+    def __init__(self, method):
         self.method = method
+        self.procmem_type = ProcessMemory
         self.weak = False
-        self.needs_exec = None
-        self.final = False
-        self.yara_string = method.__name__
         functools.update_wrapper(self, method)
 
-    def __call__(self, extractor: "Extractor", *args, **kwargs) -> None:
+    def __call__(self, extractor, procmem, *args, **kwargs):
+        if not isinstance(procmem, self.procmem_type):
+            log.debug(
+                "Omitting %s.%s - %s is not %s",
+                self.__class__.__name__,
+                self.method.__name__,
+                procmem.__class__.__name__,
+                self.procmem_type.__name__,
+            )
+            return
         # Get config from extractor method
-        config = self.method(extractor, *args, **kwargs)
+        config = self.method(extractor, procmem, *args, **kwargs)
         if not config:
             return
         # If method returns True - family matched (for non-weak methods)
@@ -73,86 +40,36 @@ class ExtractorMethod:
         if not self.weak and extractor.family and "family" not in config:
             config["family"] = extractor.family
         # If config is not empty - push it
-        if config:
+        if config and isinstance(config, dict):
             extractor.push_config(config)
 
 
-class ExtractorBase:
-    family = None  #: Extracted malware family, automatically added to "family" key for strong extraction methods
-    overrides: List[
-        str
-    ] = []  #: Family match overrides another match e.g. citadel overrides zeus
-
-    def __init__(self, parent: "ProcmemExtractManager") -> None:
-        self.parent = parent  #: ProcmemExtractManager instance
-
-    def push_procmem(self, procmem: ProcessMemory, **info):
-        """
-        Push procmem object for further analysis
-
-        :param procmem: ProcessMemory object
-        :type procmem: :class:`malduck.procmem.ProcessMemory`
-        :param info: Additional info about object
-        """
-        return self.parent.push_procmem(procmem, **info)
-
-    def push_config(self, config):
-        """
-        Push partial config (used by :py:meth:`Extractor.handle_yara`)
-
-        :param config: Partial config element
-        :type config: dict
-        """
-        return self.parent.push_config(config, self)
-
-    @property
-    def matched(self) -> bool:
-        """
-        Returns True if family has been matched so far
-
-        :rtype: bool
-        """
-        return self.parent.family is not None
-
-    @property
-    def collected_config(self) -> Config:
-        """
-        Shows collected config so far (useful in "final" extractors)
-
-        :rtype: dict
-        """
-        return self.parent.collected_config
-
-    @property
-    def globals(self) -> Dict[str, Any]:
-        """
-        Container for global variables associated with analysis
-
-        :rtype: dict
-        """
-        return self.parent.globals
-
-    @property
-    def log(self) -> logging.Logger:
-        """
-        Logger instance for Extractor methods
-
-        :return: :class:`logging.Logger`
-        """
-        return logging.getLogger(
-            f"{self.__class__.__module__}.{self.__class__.__name__}"
-        )
+class StringExtractorMethod(ExtractorMethod):
+    def __init__(self, method, string_name=None) -> None:
+        super().__init__(method)
+        self.string_name = string_name or method.__name__
 
 
-class Extractor(ExtractorBase, metaclass=MetaExtractor):
+class RuleExtractorMethod(ExtractorMethod):
+    def __init__(self, method, rule_name=None):
+        super().__init__(method)
+        self.rule_name = rule_name or method.__name__
+
+
+class FinalExtractorMethod(ExtractorMethod):
+    def __init__(self, method):
+        super().__init__(method)
+
+
+class Extractor:
     """
     Base class for extractor modules
 
     Following parameters need to be defined:
 
-    * :py:attr:`family` (see :py:attr:`extractor.ExtractorBase.family`)
+    * :py:attr:`family` (see :py:attr:`extractor.Extractor.family`)
     * :py:attr:`yara_rules`
-    * :py:attr:`overrides` (optional, see :py:attr:`extractor.ExtractorBase.overrides`)
+    * :py:attr:`overrides` (optional, see :py:attr:`extractor.Extractor.overrides`)
 
     Example extractor code for Citadel:
 
@@ -241,14 +158,78 @@ class Extractor(ExtractorBase, metaclass=MetaExtractor):
 
     """
 
-    yara_rules: Tuple[
-        str, ...
-    ] = ()  #: Names of Yara rules for which handle_yara is called
+    yara_rules = ()  #: Names of Yara rules for which handle_yara is called
+    family = None  #: Extracted malware family, automatically added to "family" key for strong extraction methods
+    overrides = []  #: Family match overrides another match e.g. citadel overrides zeus
 
-    extractor_methods: Dict[str, str]
-    final_methods: Dict[str, str]
+    def __init__(self, parent) -> None:
+        self.parent = parent
 
-    def on_error(self, exc: Exception, method_name: str) -> None:
+    def push_procmem(self, procmem: ProcessMemory, **info):
+        """
+        Push procmem object for further analysis
+
+        :param procmem: ProcessMemory object
+        :type procmem: :class:`malduck.procmem.ProcessMemory`
+        :param info: Additional info about object
+        """
+        return self.parent.push_procmem(procmem, **info)
+
+    def push_config(self, config):
+        """
+        Push partial config (used by :py:meth:`Extractor.handle_yara`)
+
+        :param config: Partial config element
+        :type config: dict
+        """
+        return self.parent.push_config(config, self)
+
+    @property
+    def matched(self):
+        """
+        Returns True if family has been matched so far
+
+        :rtype: bool
+        """
+        return self.parent.family is not None
+
+    @property
+    def collected_config(self):
+        """
+        Shows collected config so far (useful in "final" extractors)
+
+        :rtype: dict
+        """
+        return self.parent.collected_config
+
+    @property
+    def globals(self):
+        """
+        Container for global variables associated with analysis
+
+        :rtype: dict
+        """
+        return self.parent.globals
+
+    @property
+    def log(self):
+        """
+        Logger instance for Extractor methods
+
+        :return: :class:`logging.Logger`
+        """
+        return logging.getLogger(
+            f"{self.__class__.__module__}.{self.__class__.__name__}"
+        )
+
+    def _get_methods(self, method_type):
+        return (
+            (name, method)
+            for name, method in self.__class__.__dict__.items()
+            if isinstance(method, method_type)
+        )
+
+    def on_error(self, exc, method_name):
         """
         Handler for all Exception's throwed by extractor methods.
 
@@ -259,7 +240,7 @@ class Extractor(ExtractorBase, metaclass=MetaExtractor):
         """
         self.parent.on_extractor_error(exc, self, method_name)
 
-    def handle_yara(self, p: ProcessMemory, match: YaraMatches) -> None:
+    def handle_yara(self, p, match):
         """
         Override this if you don't want to use decorators and customize ripping process
         (e.g. yara-independent, brute-force techniques)
@@ -267,26 +248,15 @@ class Extractor(ExtractorBase, metaclass=MetaExtractor):
         :param p: ProcessMemory object
         :type p: :class:`malduck.procmem.ProcessMemory`
         :param match: Found yara matches for this family
-        :type match: :class:`malduck.yara.YaraMatches`
+        :type match: :class:`malduck.yara.YaraMatch`
         """
         # Call string-based extractors
-        for identifier, method_name in self.extractor_methods.items():
+        for method_name, method in self._get_methods(StringExtractorMethod):
+            identifier = method.string_name
             if identifier not in match:
                 continue
-            method = getattr(self, method_name)
             for va in match[identifier]:
                 try:
-                    if method.needs_exec and not isinstance(p, method.needs_exec):
-                        log.debug(
-                            "Omitting %s.%s for %s@%x - %s is not %s",
-                            self.__class__.__name__,
-                            method_name,
-                            identifier,
-                            va,
-                            p.__class__.__name__,
-                            method.needs_exec.__name__,
-                        )
-                        continue
                     log.debug(
                         "Trying %s.%s for %s@%x",
                         self.__class__.__name__,
@@ -298,18 +268,18 @@ class Extractor(ExtractorBase, metaclass=MetaExtractor):
                 except Exception as exc:
                     self.on_error(exc, method_name)
 
-        # Call final extractors
-        for method_name in self.final_methods:
-            method = getattr(self, method_name)
-            if method.needs_exec and not isinstance(p, method.needs_exec):
-                log.debug(
-                    "Omitting %s.%s (final) - %s is not %s",
-                    self.__class__.__name__,
-                    method_name,
-                    p.__class__.__name__,
-                    method.needs_exec.__name__,
-                )
+        # Call rule-based extractors
+        for method_name, method in self._get_methods(RuleExtractorMethod):
+            if match.name != method.rule_name:
                 continue
+            log.debug("Trying %s.%s (rule)", self.__class__.__name__, method_name)
+            try:
+                method(self, p, match)
+            except Exception as exc:
+                self.on_error(exc, method_name)
+
+        # Call final extractors
+        for method_name, method in self._get_methods(FinalExtractorMethod):
             log.debug("Trying %s.%s (final)", self.__class__.__name__, method_name)
             try:
                 method(self, p)
@@ -317,53 +287,59 @@ class Extractor(ExtractorBase, metaclass=MetaExtractor):
                 self.on_error(exc, method_name)
 
     # Extractor method decorators
+    @staticmethod
+    def extractor(string_or_method):
+        if callable(string_or_method):
+            if isinstance(string_or_method, ExtractorMethod):
+                raise TypeError("@extractor decorator must be first")
+            return StringExtractorMethod(string_or_method)
+        elif isinstance(string_or_method, str):
+            def extractor_wrapper(method):
+                if isinstance(string_or_method, ExtractorMethod):
+                    raise TypeError("@extractor decorator must be first")
+                return StringExtractorMethod(method, string_name=string_or_method)
+            return extractor_wrapper
+        else:
+            raise TypeError("Expected string or callable argument")
+
+    @staticmethod
+    def rule(string_or_method):
+        if callable(string_or_method):
+            if isinstance(string_or_method, ExtractorMethod):
+                raise TypeError("@rule decorator must be first")
+            return RuleExtractorMethod(string_or_method)
+        elif isinstance(string_or_method, str):
+            def extractor_wrapper(method):
+                if isinstance(string_or_method, ExtractorMethod):
+                    raise TypeError("@rule decorator must be first")
+                return RuleExtractorMethod(method, rule_name=string_or_method)
+            return extractor_wrapper
+        else:
+            raise TypeError("Expected string or callable argument")
+
+    @staticmethod
+    def final(method):
+        if isinstance(method, ExtractorMethod):
+            raise TypeError("@final decorator must be first")
+        return FinalExtractorMethod(method)
 
     @staticmethod
     def needs_pe(method):
-        method = Extractor._extractor_method(method)
-        method.needs_exec = ProcessMemoryPE
+        if not isinstance(method, ExtractorMethod):
+            raise TypeError("@needs_pe decorator must be placed before @final/@rule/@extractor decorator")
+        method.procmem_type = ProcessMemoryPE
         return method
 
     @staticmethod
     def needs_elf(method):
-        method = Extractor._extractor_method(method)
-        method.needs_exec = ProcessMemoryELF
+        if not isinstance(method, ExtractorMethod):
+            raise TypeError("@needs_elf decorator must be placed before @final/@rule/@extractor decorator")
+        method.procmem_type = ProcessMemoryELF
         return method
 
     @staticmethod
     def weak(method):
-        method = Extractor._extractor_method(method)
+        if not isinstance(method, ExtractorMethod):
+            raise TypeError("@weak decorator must be placed before @final/@rule/@extractor decorator")
         method.weak = True
         return method
-
-    @staticmethod
-    def extractor(string_or_method=None, final=False):
-        if final and string_or_method:
-            raise ValueError("String identifier is unnecessary for final methods")
-
-        def extractor_wrapper(method):
-            extractor_method = Extractor._extractor_method(method)
-            # If there is string provided, use it as yara_string
-            if string_or_method and not callable(string_or_method):
-                extractor_method.yara_string = string_or_method
-            extractor_method.final = final
-            return extractor_method
-
-        if callable(string_or_method):
-            return extractor_wrapper(string_or_method)
-        else:
-            return extractor_wrapper
-
-    @staticmethod
-    def final(method):
-        return Extractor.extractor(final=True)(method)
-
-    # Internals
-
-    @staticmethod
-    def _extractor_method(method):
-        # Check whether method is already wrapped by ExtractorMethod
-        if isinstance(method, ExtractorMethod):
-            return method
-        else:
-            return ExtractorMethod(method)

--- a/malduck/extractor/extractor.pyi
+++ b/malduck/extractor/extractor.pyi
@@ -1,0 +1,122 @@
+import logging
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Iterator,
+    Optional,
+    Union,
+    Tuple,
+    Type,
+    TypeVar,
+    overload,
+)
+from typing_extensions import Protocol
+
+from ..procmem import ProcessMemory, ProcessMemoryPE, ProcessMemoryELF
+from ..yara import YaraMatch
+
+from .extract_manager import ProcmemExtractManager
+
+Config = Dict[str, Any]
+
+T = TypeVar("T", bound="Extractor", contravariant=True)
+U = TypeVar("U", bound=ProcessMemory, contravariant=True)
+V = TypeVar("V", bound="ExtractorMethod")
+
+class _StringCallback(Protocol[T, U]):
+    def __call__(cls, self: T, procmem: U, addr: int) -> Union[Config, bool, None]: ...
+
+class _RuleCallback(Protocol[T, U]):
+    def __call__(
+        cls, self: T, procmem: U, matches: YaraMatch
+    ) -> Union[Config, bool, None]: ...
+
+class _FinalCallback(Protocol[T, U]):
+    def __call__(cls, self: T, procmem: U) -> Union[Config, bool, None]: ...
+
+class ExtractorMethod(Generic[T, U]):
+    """
+    Represents registered extractor method
+    """
+    method: Union[_StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]]
+    procmem_type: Type["ProcessMemory"]
+    weak: bool
+
+    def __init__(
+        self,
+        method: Union[_StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]],
+    ) -> None: ...
+    def __call__(self, extractor: T, procmem: U, *args, **kwargs) -> None: ...
+
+class StringExtractorMethod(ExtractorMethod[T, U]):
+    string_name: str
+    def __init__(
+        self, method: _StringCallback[T, U], string_name: Optional[str] = None
+    ) -> None:
+        super().__init__(method)
+
+class RuleExtractorMethod(ExtractorMethod[T, U]):
+    rule_name: str
+    def __init__(
+        self, method: _RuleCallback[T, U], rule_name: Optional[str] = None
+    ) -> None:
+        super().__init__(method)
+
+class FinalExtractorMethod(ExtractorMethod[T, U]):
+    def __init__(self, method: _FinalCallback[T, U]) -> None:
+        super().__init__(method)
+
+class Extractor:
+    yara_rules: Tuple[str, ...]
+    family: Optional[str]
+    overrides: List[str]
+    parent: ProcmemExtractManager
+    def __init__(self, parent: ProcmemExtractManager) -> None: ...
+    def push_procmem(self, procmem: ProcessMemory, **info): ...
+    def push_config(self, config): ...
+    @property
+    def matched(self) -> bool: ...
+    @property
+    def collected_config(self) -> Config: ...
+    @property
+    def globals(self) -> Dict[str, Any]: ...
+    @property
+    def log(self) -> logging.Logger: ...
+    def _get_methods(self, method_type: Type[V]) -> Iterator[Tuple[str, V]]: ...
+    def on_error(self, exc: Exception, method_name: str) -> None: ...
+    def handle_yara(self, p: ProcessMemory, match: YaraMatch) -> None: ...
+    # Extractor method decorators
+    @overload
+    @staticmethod
+    def extractor(
+        string_or_method: _StringCallback[T, U]
+    ) -> StringExtractorMethod[T, U]: ...
+    @overload
+    @staticmethod
+    def extractor(
+        string_or_method: str,
+    ) -> Callable[[_StringCallback[T, U]], StringExtractorMethod[T, U]]: ...
+    @overload
+    @staticmethod
+    def rule(string_or_method: _RuleCallback[T, U]) -> RuleExtractorMethod[T, U]: ...
+    @overload
+    @staticmethod
+    def rule(
+        string_or_method: str,
+    ) -> Callable[[_RuleCallback[T, U]], RuleExtractorMethod[T, U]]: ...
+    @staticmethod
+    def final(method: _FinalCallback[T, U]) -> FinalExtractorMethod[T, U]: ...
+    @staticmethod
+    def needs_pe(
+        method: ExtractorMethod[T, ProcessMemoryPE]
+    ) -> ExtractorMethod[T, ProcessMemoryPE]: ...
+    @staticmethod
+    def needs_elf(
+        method: ExtractorMethod[T, ProcessMemoryELF]
+    ) -> ExtractorMethod[T, ProcessMemoryELF]: ...
+    @staticmethod
+    def weak(method: ExtractorMethod[T, U]) -> ExtractorMethod[T, U]: ...

--- a/malduck/extractor/extractor.pyi
+++ b/malduck/extractor/extractor.pyi
@@ -28,24 +28,24 @@ U = TypeVar("U", bound=ProcessMemory, contravariant=True)
 V = TypeVar("V", bound="ExtractorMethod")
 
 class _StringCallback(Protocol[T, U]):
-    def __call__(cls, self: T, procmem: U, addr: int) -> Union[Config, bool, None]: ...
+    def __call__(cls, self: T, p: U, addr: int) -> Union[Config, bool, None]: ...
 
 class _RuleCallback(Protocol[T, U]):
     def __call__(
-        cls, self: T, procmem: U, matches: YaraMatch
+        cls, self: T, p: U, matches: YaraMatch
     ) -> Union[Config, bool, None]: ...
 
 class _FinalCallback(Protocol[T, U]):
-    def __call__(cls, self: T, procmem: U) -> Union[Config, bool, None]: ...
+    def __call__(cls, self: T, p: U) -> Union[Config, bool, None]: ...
 
 class ExtractorMethod(Generic[T, U]):
     """
     Represents registered extractor method
     """
+
     method: Union[_StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]]
     procmem_type: Type["ProcessMemory"]
     weak: bool
-
     def __init__(
         self,
         method: Union[_StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]],

--- a/malduck/procmem/procmem.pyi
+++ b/malduck/procmem/procmem.pyi
@@ -28,7 +28,7 @@ from ..ints import IntType
 ProcessMemoryBuffer = Union[bytes, bytearray, mmap.mmap]
 T = TypeVar("T", bound="ProcessMemory")
 
-procmem: "ProcessMemory"
+procmem: Type["ProcessMemory"]
 
 class ProcessMemory:
     f: Optional[BinaryIO]

--- a/malduck/yara.py
+++ b/malduck/yara.py
@@ -8,7 +8,7 @@ import textwrap
 import yara
 
 
-__all__ = ["Yara", "YaraString", "YaraMatches"]
+__all__ = ["Yara", "YaraString", "YaraMatch", "YaraMatches"]
 
 log = logging.getLogger(__name__)
 

--- a/tests/files/modules/olly/olly.py
+++ b/tests/files/modules/olly/olly.py
@@ -12,3 +12,7 @@ class Ollydbg(Extractor):
     @Extractor.extractor("olly_is_not")
     def olly_isnt(self, p, hit):
         return {"olly": [p.asciiz(hit).decode("utf8")]}
+
+    @Extractor.rule("WhatOllyIsNot")
+    def olly_isnt_rule(self, p, matches):
+        return {"matches": list(matches.keys())}

--- a/tests/files/modules/weak/weak.py
+++ b/tests/files/modules/weak/weak.py
@@ -10,8 +10,8 @@ class Weaky(Extractor):
     def weaky(self, p, hit):
         return {"weak": True}
 
-    @Extractor.extractor
     @Extractor.weak
+    @Extractor.extractor
     def weaky2(self, p, hit):
         return {"weaky": True}
 
@@ -20,5 +20,6 @@ class Weaky(Extractor):
         return True
 
     @Extractor.weak
+    @Extractor.extractor
     def nonsense_weak(self, p, hit):
         return True

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -34,6 +34,7 @@ def test_scan_ollydbg():
         " - OllyDbg is in Explorer's menu\n",
         " - OllyDbg is not in Explorer's menu"
     ]
+    assert "olly_is_not" in cfg["matches"]
 
 
 def test_apliebe():


### PR DESCRIPTION
- Simplified `Extractor` classes. Removed `MetaExtractor` metaclass and `ExtractorBase` base class
- Added rule-based methods (`@Extractor.rule`, closes #6)
- Much better typings for extractor method decorators:
    - You can't mix `@final`, `@rule` and `@extractor` decorators
    - Strict signature check-up of decorated methods
    - `@needs_pe` allows to set `p: ProcessMemoryPE` typing and forbids `p: ProcessMemoryELF`
    - `@weak`, `@needs_*` decorators can be used only on methods already decorated by `@final`/`@rule`/`@extractor`
- Fixed documentation