### PR TITLE
Extended Yara match structures, @Extractor.string with additional `match` argument

### DIFF
--- a/malduck/__init__.py
+++ b/malduck/__init__.py
@@ -110,7 +110,7 @@ from .structure import Structure
 
 from .verify import verify
 
-from .yara import Yara, YaraString
+from .yara import Yara, YaraString, YaraStringMatch
 
 __all__ = [
     # bits
@@ -236,6 +236,7 @@ __all__ = [
     # verify
     "verify",
     # yara
+    "YaraStringMatch",
     "YaraString",
     "Yara",
 ]

--- a/malduck/extractor/extract_manager.py
+++ b/malduck/extractor/extract_manager.py
@@ -1,9 +1,10 @@
 import json
 import logging
 import os
+import warnings
 from typing import Any, Dict, Optional, List, Type, Union
 
-from ..yara import Yara, YaraMatches
+from ..yara import Yara, YaraMatches, YaraStringOffsets
 from ..procmem import ProcessMemory
 from .extractor import Extractor
 from .loaders import load_modules
@@ -316,7 +317,18 @@ class ProcmemExtractManager:
             for rule in extractor.yara_rules:
                 if rule in matches:
                     try:
-                        extractor.handle_yara(p, matches[rule])
+                        if hasattr(extractor, "handle_yara"):
+                            warnings.warn(
+                                "Extractor.handle_yara is deprecated, use Extractor.handle_match",
+                                DeprecationWarning
+                            )
+                            getattr(extractor, "handle_yara")(
+                                p, YaraStringOffsets(matches[rule])
+                            )
+                        else:
+                            extractor.handle_match(
+                                p, matches[rule]
+                            )
                     except Exception as exc:
                         self.parent.on_error(exc, extractor)
 

--- a/malduck/extractor/extract_manager.py
+++ b/malduck/extractor/extract_manager.py
@@ -4,7 +4,7 @@ import os
 import warnings
 from typing import Any, Dict, Optional, List, Type, Union
 
-from ..yara import Yara, YaraMatches, YaraStringOffsets
+from ..yara import Yara, YaraMatches, YaraRuleOffsets
 from ..procmem import ProcessMemory
 from .extractor import Extractor
 from .loaders import load_modules
@@ -239,8 +239,7 @@ class ExtractManager:
         def extract_config(procmem: ProcessMemory) -> Optional[str]:
             log.debug("%s - ripping...", fmt_procmem(procmem))
             extractor = ProcmemExtractManager(self)
-            matches.remap(procmem.p2v)
-            extractor.push_procmem(procmem, _matches=matches)
+            extractor.push_procmem(procmem, _matches=matches.remap(procmem.p2v))
             if extractor.family:
                 log.debug("%s - found %s!", fmt_procmem(procmem), extractor.family)
                 return self.push_config(extractor.family, extractor.config)
@@ -323,7 +322,7 @@ class ProcmemExtractManager:
                                 DeprecationWarning
                             )
                             getattr(extractor, "handle_yara")(
-                                p, YaraStringOffsets(matches[rule])
+                                p, YaraRuleOffsets(matches[rule])
                             )
                         else:
                             extractor.handle_match(

--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -423,8 +423,8 @@ class Extractor:
                             "Trying %s.%s for %s@%x",
                             self.__class__.__name__,
                             method_name,
-                            identifier,
-                            string_match,
+                            string_match.identifier,
+                            string_match.hit,
                         )
                         method(self, p, string_match.hit, string_match)
                     except Exception as exc:

--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -407,7 +407,7 @@ class Extractor:
                         identifier,
                         string_match,
                     )
-                    method(self, p, string_match.hit)
+                    method(self, p, string_match.offset)
                 except Exception as exc:
                     self.on_error(exc, method_name)
 
@@ -424,9 +424,9 @@ class Extractor:
                             self.__class__.__name__,
                             method_name,
                             string_match.identifier,
-                            string_match.hit,
+                            string_match.offset,
                         )
-                        method(self, p, string_match.hit, string_match)
+                        method(self, p, string_match.offset, string_match)
                     except Exception as exc:
                         self.on_error(exc, method_name)
 

--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -481,6 +481,7 @@ class Extractor:
                 if isinstance(method, ExtractorMethod):
                     raise TypeError("@extractor decorator must be first")
                 return StringExtractorMethod(method, string_names=strings)
+
             return extractor_wrapper
         else:
             raise TypeError("Expected strings or single callable argument")

--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -108,6 +108,13 @@ class Extractor:
                 if p.is_addr(hit):
                     return {'login_key': p.asciiz(hit)}
 
+    Decorated methods are always called in order:
+
+    - `@Extractor.extractor` methods
+    - `@Extractor.string` methods
+    - `@Extractor.rule` methods
+    - `@Extractor.final` methods
+
     .. py:decoratormethod:: Extractor.string
 
         Decorator for string-based extractor methods.

--- a/malduck/extractor/extractor.pyi
+++ b/malduck/extractor/extractor.pyi
@@ -31,7 +31,9 @@ class _StringOffsetCallback(Protocol[T, U]):
     def __call__(cls, self: T, p: U, addr: int) -> Union[Config, bool, None]: ...
 
 class _StringCallback(Protocol[T, U]):
-    def __call__(cls, self: T, p: U, addr: int, match: YaraStringMatch) -> Union[Config, bool, None]: ...
+    def __call__(
+        cls, self: T, p: U, addr: int, match: YaraStringMatch
+    ) -> Union[Config, bool, None]: ...
 
 class _RuleCallback(Protocol[T, U]):
     def __call__(
@@ -46,12 +48,22 @@ class ExtractorMethod(Generic[T, U]):
     Represents registered extractor method
     """
 
-    method: Union[_StringOffsetCallback[T, U], _StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]]
+    method: Union[
+        _StringOffsetCallback[T, U],
+        _StringCallback[T, U],
+        _RuleCallback[T, U],
+        _FinalCallback[T, U],
+    ]
     procmem_type: Type["ProcessMemory"]
     weak: bool
     def __init__(
         self,
-        method: Union[_StringOffsetCallback[T, U], _StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]],
+        method: Union[
+            _StringOffsetCallback[T, U],
+            _StringCallback[T, U],
+            _RuleCallback[T, U],
+            _FinalCallback[T, U],
+        ],
     ) -> None: ...
     def __call__(self, extractor: T, procmem: U, *args, **kwargs) -> None: ...
 
@@ -110,7 +122,6 @@ class Extractor:
     def extractor(
         string_or_method: str,
     ) -> Callable[[_StringOffsetCallback[T, U]], StringOffsetExtractorMethod[T, U]]: ...
-
     @overload
     @staticmethod
     def string(
@@ -121,7 +132,6 @@ class Extractor:
     def string(
         *strings_or_method: str,
     ) -> Callable[[_StringCallback[T, U]], StringExtractorMethod[T, U]]: ...
-
     @overload
     @staticmethod
     def rule(string_or_method: _RuleCallback[T, U]) -> RuleExtractorMethod[T, U]: ...

--- a/malduck/extractor/extractor.pyi
+++ b/malduck/extractor/extractor.pyi
@@ -17,7 +17,7 @@ from typing import (
 from typing_extensions import Protocol
 
 from ..procmem import ProcessMemory, ProcessMemoryPE, ProcessMemoryELF
-from ..yara import YaraMatch
+from ..yara import YaraRuleMatch, YaraStringMatch
 
 from .extract_manager import ProcmemExtractManager
 
@@ -27,12 +27,15 @@ T = TypeVar("T", bound="Extractor", contravariant=True)
 U = TypeVar("U", bound=ProcessMemory, contravariant=True)
 V = TypeVar("V", bound="ExtractorMethod")
 
-class _StringCallback(Protocol[T, U]):
+class _StringOffsetCallback(Protocol[T, U]):
     def __call__(cls, self: T, p: U, addr: int) -> Union[Config, bool, None]: ...
+
+class _StringCallback(Protocol[T, U]):
+    def __call__(cls, self: T, p: U, addr: int, match: YaraStringMatch) -> Union[Config, bool, None]: ...
 
 class _RuleCallback(Protocol[T, U]):
     def __call__(
-        cls, self: T, p: U, matches: YaraMatch
+        cls, self: T, p: U, match: YaraRuleMatch
     ) -> Union[Config, bool, None]: ...
 
 class _FinalCallback(Protocol[T, U]):
@@ -43,19 +46,26 @@ class ExtractorMethod(Generic[T, U]):
     Represents registered extractor method
     """
 
-    method: Union[_StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]]
+    method: Union[_StringOffsetCallback[T, U], _StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]]
     procmem_type: Type["ProcessMemory"]
     weak: bool
     def __init__(
         self,
-        method: Union[_StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]],
+        method: Union[_StringOffsetCallback[T, U], _StringCallback[T, U], _RuleCallback[T, U], _FinalCallback[T, U]],
     ) -> None: ...
     def __call__(self, extractor: T, procmem: U, *args, **kwargs) -> None: ...
 
-class StringExtractorMethod(ExtractorMethod[T, U]):
+class StringOffsetExtractorMethod(ExtractorMethod[T, U]):
     string_name: str
     def __init__(
-        self, method: _StringCallback[T, U], string_name: Optional[str] = None
+        self, method: _StringOffsetCallback[T, U], string_name: Optional[str] = None
+    ) -> None:
+        super().__init__(method)
+
+class StringExtractorMethod(ExtractorMethod[T, U]):
+    string_names: List[str]
+    def __init__(
+        self, method: _StringCallback[T, U], string_names: Optional[List[str]] = None
     ) -> None:
         super().__init__(method)
 
@@ -88,18 +98,30 @@ class Extractor:
     def log(self) -> logging.Logger: ...
     def _get_methods(self, method_type: Type[V]) -> Iterator[Tuple[str, V]]: ...
     def on_error(self, exc: Exception, method_name: str) -> None: ...
-    def handle_yara(self, p: ProcessMemory, match: YaraMatch) -> None: ...
+    def handle_match(self, p: ProcessMemory, match: YaraRuleMatch) -> None: ...
     # Extractor method decorators
     @overload
     @staticmethod
     def extractor(
-        string_or_method: _StringCallback[T, U]
-    ) -> StringExtractorMethod[T, U]: ...
+        string_or_method: _StringOffsetCallback[T, U]
+    ) -> StringOffsetExtractorMethod[T, U]: ...
     @overload
     @staticmethod
     def extractor(
         string_or_method: str,
+    ) -> Callable[[_StringOffsetCallback[T, U]], StringOffsetExtractorMethod[T, U]]: ...
+
+    @overload
+    @staticmethod
+    def string(
+        *strings_or_method: _StringCallback[T, U]
+    ) -> StringExtractorMethod[T, U]: ...
+    @overload
+    @staticmethod
+    def string(
+        *strings_or_method: str,
     ) -> Callable[[_StringCallback[T, U]], StringExtractorMethod[T, U]]: ...
+
     @overload
     @staticmethod
     def rule(string_or_method: _RuleCallback[T, U]) -> RuleExtractorMethod[T, U]: ...

--- a/malduck/procmem/procmem.py
+++ b/malduck/procmem/procmem.py
@@ -793,7 +793,7 @@ class ProcessMemory:
         match = yara_fn(rule, addr, length, True)
         if match:
             for string_match in match.r.string:
-                yield string_match.hit
+                yield string_match.offset
 
     def findbytesp(self, query, offset=None, length=None):
         """

--- a/malduck/procmem/procmem.py
+++ b/malduck/procmem/procmem.py
@@ -726,11 +726,16 @@ class ProcessMemory:
         extract_manager.push_procmem(self)
         return extract_manager.config
 
-    def yarap(self, ruleset, offset=None, length=None):
+    def yarap(self, ruleset, offset=None, length=None, extended=False):
         """
         Perform yara matching (non-region-wise)
 
         If offset is None, looks for match from the beginning of memory
+
+        .. versionchanged:: 4.0.0:
+
+            Added `extended` option which allows to get extended information about matched strings and rules.
+            Default is False for backwards compatibility.
 
         :param ruleset: Yara object with loaded yara rules
         :type ruleset: :class:`malduck.yara.Yara`
@@ -738,15 +743,22 @@ class ProcessMemory:
         :type offset: int (optional)
         :param length: Length of searched area
         :type length: int (optional)
+        :param extended: Returns extended information about matched strings and rules
+        :type extended: bool (optional, default False)
         :rtype: :class:`malduck.yara.YaraMatches`
         """
-        return ruleset.match(data=self.readp(offset or 0, length))
+        return ruleset.match(extended=extended, data=self.readp(offset or 0, length))
 
-    def yarav(self, ruleset, addr=None, length=None):
+    def yarav(self, ruleset, addr=None, length=None, extended=False):
         """
         Perform yara matching (region-wise)
 
         If addr is None, looks for match from the beginning of memory
+
+        .. versionchanged:: 4.0.0:
+
+            Added `extended` option which allows to get extended information about matched strings and rules.
+            Default is False for backwards compatibility.
 
         :param ruleset: Yara object with loaded yara rules
         :type ruleset: :class:`malduck.yara.Yara`
@@ -754,7 +766,10 @@ class ProcessMemory:
         :type addr: int (optional)
         :param length: Length of searched area
         :type length: int (optional)
-        :rtype: :class:`malduck.yara.YaraMatches`
+        :param extended: Returns extended information about matched strings and rules
+        :type extended: bool (optional, default False)
+        :rtype: :class:`malduck.yara.YaraRulesetOffsets` or :class:`malduck.yara.YaraRulesetMatches`
+                if extended is set to True
         """
         if addr is None:
             addr = self.regions[0].addr
@@ -766,14 +781,16 @@ class ProcessMemory:
             if ptr is not None and addr <= ptr < addr + length:
                 return ptr
 
-        return ruleset.match(data=self.readp(0), offset_mapper=map_offset)
+        return ruleset.match(
+            offset_mapper=map_offset, extended=extended, data=self.readp(0)
+        )
 
     def _findbytes(self, yara_fn, query, addr, length):
         if isinstance(query, bytes):
             query = query.decode()
 
         rule = Yara(strings=YaraString(query, type=YaraString.HEX))
-        match = yara_fn(rule, addr, length)
+        match = yara_fn(rule, addr, length, True)
         if match:
             for string_match in match.r.string:
                 yield string_match.hit

--- a/malduck/procmem/procmem.py
+++ b/malduck/procmem/procmem.py
@@ -775,9 +775,8 @@ class ProcessMemory:
         rule = Yara(strings=YaraString(query, type=YaraString.HEX))
         match = yara_fn(rule, addr, length)
         if match:
-            return match.r.string
-        else:
-            return []
+            for string_match in match.r.string:
+                yield string_match.hit
 
     def findbytesp(self, query, offset=None, length=None):
         """
@@ -797,7 +796,7 @@ class ProcessMemory:
         :return: Iterator returning next offsets
         :rtype: Iterator[int]
         """
-        return iter(self._findbytes(self.yarap, query, offset, length))
+        return self._findbytes(self.yarap, query, offset, length)
 
     def findbytesv(self, query, addr=None, length=None):
         """
@@ -829,7 +828,7 @@ class ProcessMemory:
                 if hex(mem.readv(va, 5)) == "4aaabbccdd":
                     findings.append(va)
         """
-        return iter(self._findbytes(self.yarav, query, addr, length))
+        return self._findbytes(self.yarav, query, addr, length)
 
     def findmz(self, addr):
         """

--- a/malduck/procmem/procmem.py
+++ b/malduck/procmem/procmem.py
@@ -790,7 +790,7 @@ class ProcessMemory:
             query = query.decode()
 
         rule = Yara(strings=YaraString(query, type=YaraString.HEX))
-        match = yara_fn(rule, addr, length, True)
+        match = yara_fn(rule, addr, length, extended=True)
         if match:
             for string_match in match.r.string:
                 yield string_match.offset

--- a/malduck/procmem/procmem.pyi
+++ b/malduck/procmem/procmem.pyi
@@ -216,7 +216,7 @@ class ProcessMemory:
         query: Union[str, bytes],
         addr: Optional[int],
         length: Optional[int],
-    ) -> List[int]: ...
+    ) -> Iterator[int]: ...
     def findbytesp(
         self,
         query: Union[str, bytes],

--- a/malduck/procmem/procmem.pyi
+++ b/malduck/procmem/procmem.pyi
@@ -21,7 +21,7 @@ from ..extractor import ExtractorModules, ExtractManager
 
 from .region import Region
 from ..disasm import Instruction
-from ..yara import Yara, YaraMatches
+from ..yara import Yara, YaraRulesetMatch, YaraRulesetOffsets
 
 from ..ints import IntType
 
@@ -204,15 +204,81 @@ class ProcessMemory:
     def extract(
         self, modules: ExtractorModules = None, extract_manager: ExtractManager = None,
     ) -> Optional[List[Dict[str, Any]]]: ...
+    # yarap(ruleset)
+    # yarap(ruleset, offset)
+    # yarap(ruleset, offset, length)
+    # yarap(ruleset, offset, length, extended=False)
+    @overload
     def yarap(
-        self, ruleset: Yara, offset: Optional[int] = None, length: Optional[int] = None
-    ) -> YaraMatches: ...
+        self,
+        ruleset: Yara,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
+        extended: Literal[False] = False,
+    ) -> YaraRulesetOffsets: ...
+    # yarap(ruleset, offset, length, extended=True)
+    @overload
+    def yarap(
+        self,
+        ruleset: Yara,
+        offset: Optional[int],
+        length: Optional[int],
+        extended: Literal[True],
+    ) -> YaraRulesetMatch: ...
+    # yarap(ruleset, extended=True)
+    @overload
+    def yarap(self, ruleset: Yara, *, extended: Literal[True]) -> YaraRulesetMatch: ...
+    # yarap(ruleset, offset=0, extended=True)
+    # yarap(ruleset, 0, extended=True)
+    @overload
+    def yarap(
+        self, ruleset: Yara, offset: Optional[int], *, extended: Literal[True]
+    ) -> YaraRulesetMatch: ...
+    # yarap(ruleset, length=0, extended=True)
+    @overload
+    def yarap(
+        self, ruleset: Yara, *, length: Optional[int], extended: Literal[True]
+    ) -> YaraRulesetMatch: ...
+    # yarav(ruleset)
+    # yarav(ruleset, addr)
+    # yarav(ruleset, addr, length)
+    # yarav(ruleset, addr, length, extended=False)
+    @overload
     def yarav(
-        self, ruleset: Yara, addr: Optional[int] = None, length: Optional[int] = None
-    ) -> YaraMatches: ...
+        self,
+        ruleset: Yara,
+        addr: Optional[int] = None,
+        length: Optional[int] = None,
+        extended: Literal[False] = False,
+    ) -> YaraRulesetOffsets: ...
+    # yarav(ruleset, addr, length, extended=True)
+    @overload
+    def yarav(
+        self,
+        ruleset: Yara,
+        addr: Optional[int],
+        length: Optional[int],
+        extended: Literal[True],
+    ) -> YaraRulesetMatch: ...
+    # yarav(ruleset, extended=True)
+    @overload
+    def yarav(self, ruleset: Yara, *, extended: Literal[True]) -> YaraRulesetMatch: ...
+    # yarav(ruleset, addr=0, extended=True)
+    # yarav(ruleset, 0, extended=True)
+    @overload
+    def yarav(
+        self, ruleset: Yara, addr: Optional[int], *, extended: Literal[True]
+    ) -> YaraRulesetMatch: ...
+    # yarav(ruleset, length=0, extended=True)
+    @overload
+    def yarav(
+        self, ruleset: Yara, *, length: Optional[int], extended: Literal[True]
+    ) -> YaraRulesetMatch: ...
     def _findbytes(
         self,
-        yara_fn: Callable[[Yara, Optional[int], Optional[int]], YaraMatches],
+        yara_fn: Callable[
+            [Yara, Optional[int], Optional[int], Literal[True]], YaraRulesetMatch
+        ],
         query: Union[str, bytes],
         addr: Optional[int],
         length: Optional[int],

--- a/malduck/yara.py
+++ b/malduck/yara.py
@@ -183,7 +183,10 @@ class Yara:
         :param offset_mapper: Offset mapping function. For unmapped region, should returned None.
                               Used by :py:meth:`malduck.procmem.ProcessMemory.yarav`
         :type offset_mapper: function
-        :rtype: :class:`YaraMatches`
+        :param extended: Returns extended information about matched strings and rules
+        :type extended: bool (optional, default False)
+        :rtype: :class:`malduck.yara.YaraRulesetOffsets` or :class:`malduck.yara.YaraRulesetMatches`
+                if extended is set to True
         """
         matches = YaraRulesetMatch(
             self.rules.match(**kwargs), offset_mapper=offset_mapper

--- a/malduck/yara.py
+++ b/malduck/yara.py
@@ -267,7 +267,9 @@ class YaraRulesetMatch(_Mapper):
                     continue
                 offset = _offset
             # Register offset for full identifier
-            mapped_strings[real_ident].append(YaraStringMatch(real_ident, offset, content))
+            mapped_strings[real_ident].append(
+                YaraStringMatch(real_ident, offset, content)
+            )
             # Register offset for grouped identifier
             if real_ident != group_ident:
                 mapped_strings[group_ident].append(

--- a/malduck/yara.py
+++ b/malduck/yara.py
@@ -97,7 +97,7 @@ class Yara:
             # ["mal1", "mal", "mal2"]
             print(match.MalwareRule.keys())
             if "mal" in match.MalwareRule:
-                # Note: Order of offsets for grouped is arbitrary
+                # Note: Order of offsets for grouped strings is undetermined
                 print("mal*", match.MalwareRule["mal"])
 
     :param rule_paths: Dictionary of {"namespace": "rule_path"}. See also :py:meth:`Yara.from_dir`.

--- a/malduck/yara.pyi
+++ b/malduck/yara.pyi
@@ -1,0 +1,150 @@
+from collections import namedtuple
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    List,
+    Union,
+    Tuple,
+    TypeVar,
+    Dict,
+    KeysView,
+    Optional,
+    overload,
+)
+from typing_extensions import Protocol, Literal
+
+import enum
+
+T = TypeVar("T")
+OffsetMapper = Callable[[Optional[int], Optional[int]], Optional[int]]
+
+YaraRulesString = Tuple[int, str, bytes]
+
+class YaraRulesMatch(Protocol):
+    meta: Dict[str, str]
+    namespace: str
+    rule: str
+    strings: List[YaraRulesString]
+    tags: List[str]
+
+class _Mapper(Generic[T]):
+    elements: Dict[str, T]
+    default: Optional[T]
+    def __init__(self, elements: Dict[str, T], default: Optional[T] = None) -> None: ...
+    def keys(self) -> KeysView[str]: ...
+    def get(self, item) -> Optional[T]: ...
+    def __bool__(self) -> bool: ...
+    def __nonzero__(self) -> bool: ...
+    def __contains__(self, item: str) -> bool: ...
+    def __getitem__(self, item: str) -> T: ...
+    def __getattr__(self, item: str) -> T: ...
+
+class Yara:
+    rules: Any
+    def __init__(
+        self,
+        rule_paths: Optional[Dict[str, str]] = None,
+        name: str = "r",
+        strings: Union[
+            str, "YaraString", Dict[str, Union[str, "YaraString"]], None
+        ] = None,
+        condition: str = "any of them",
+    ) -> None: ...
+    @staticmethod
+    def from_dir(
+        path: str, recursive: bool = True, followlinks: bool = True
+    ) -> "Yara": ...
+    # match(...)
+    # match(offset_mapper, ...)
+    # match(offset_mapper, extended=False, ...)
+    @overload
+    def match(
+        self,
+        offset_mapper: Optional[OffsetMapper] = None,
+        extended: Literal[False] = False,
+        **kwargs
+    ) -> "YaraRulesetOffsets": ...
+    # match(offset_mapper, extended=True, ...)
+    @overload
+    def match(
+        self, offset_mapper: Optional[OffsetMapper], extended: Literal[True], **kwargs
+    ) -> "YaraRulesetMatch": ...
+    # match(extended=True, ...)
+    @overload
+    def match(self, *, extended: Literal[True], **kwargs) -> "YaraRulesetMatch": ...
+
+class YaraStringType(enum.IntEnum):
+    TEXT = 0
+    HEX = 1
+    REGEX = 2
+
+class YaraString:
+    TEXT = YaraStringType.TEXT
+    HEX = YaraStringType.HEX
+    REGEX = YaraStringType.REGEX
+
+    value: str
+    type: YaraStringType
+    modifiers: List[str]
+    def __init__(
+        self, value: str, type: YaraStringType = YaraStringType.TEXT, **modifiers: bool
+    ) -> None: ...
+    def __str__(self) -> str: ...
+
+class YaraRulesetMatch(_Mapper["YaraRuleMatch"]):
+    _matches: List[YaraRulesMatch]
+    def __init__(
+        self,
+        matches: List[YaraRulesMatch],
+        offset_mapper: Optional[OffsetMapper] = None,
+    ) -> None:
+        super().__init__(elements={})
+    def _map_matches(
+        self, matches: List[YaraRulesMatch], offset_mapper: Optional[OffsetMapper]
+    ) -> Dict[str, "YaraRuleMatch"]: ...
+    def _map_strings(
+        self, strings: Iterable[YaraRulesString], offset_mapper: Optional[OffsetMapper]
+    ) -> Dict[str, List["YaraStringMatch"]]: ...
+    def _parse_string_identifier(self, identifier: str) -> Tuple[str, str]: ...
+    def remap(
+        self, offset_mapper: Optional[OffsetMapper] = None
+    ) -> "YaraRulesetMatch": ...
+
+class YaraRulesetOffsets(_Mapper["YaraRuleOffsets"]):
+    _matches: YaraRulesetMatch
+    def __init__(self, matches: YaraRulesetMatch) -> None:
+        super().__init__(elements={})
+    def remap(
+        self, offset_mapper: Optional[OffsetMapper] = None
+    ) -> "YaraRulesetOffsets": ...
+
+YaraStringMatch = namedtuple("YaraStringMatch", ["identifier", "hit", "content"])
+
+class YaraRuleMatch(_Mapper[List[YaraStringMatch]]):
+    rule: str
+    name: str
+    meta: Dict[str, str]
+    namespace: str
+    tags: List[str]
+    def __init__(
+        self,
+        rule: str,
+        strings: Dict[str, List[YaraStringMatch]],
+        meta: Dict[str, str],
+        namespace: str,
+        tags: List[str],
+    ) -> None:
+        super().__init__({})
+    def get_offsets(self, string) -> List[int]: ...
+
+class YaraRuleOffsets(_Mapper[List[int]]):
+    rule: str
+    name: str
+    def __init__(self, rule_match: YaraRuleMatch) -> None:
+        super().__init__({})
+
+# Legacy aliases, don't use them in new code
+YaraMatches = YaraRulesetOffsets
+YaraMatch = YaraRuleOffsets

--- a/malduck/yara.pyi
+++ b/malduck/yara.pyi
@@ -120,7 +120,7 @@ class YaraRulesetOffsets(_Mapper["YaraRuleOffsets"]):
         self, offset_mapper: Optional[OffsetMapper] = None
     ) -> "YaraRulesetOffsets": ...
 
-YaraStringMatch = namedtuple("YaraStringMatch", ["identifier", "hit", "content"])
+YaraStringMatch = namedtuple("YaraStringMatch", ["identifier", "offset", "content"])
 
 class YaraRuleMatch(_Mapper[List[YaraStringMatch]]):
     rule: str

--- a/malduck/yara.pyi
+++ b/malduck/yara.pyi
@@ -64,7 +64,7 @@ class Yara:
         self,
         offset_mapper: Optional[OffsetMapper] = None,
         extended: Literal[False] = False,
-        **kwargs
+        **kwargs,
     ) -> "YaraRulesetOffsets": ...
     # match(offset_mapper, extended=True, ...)
     @overload

--- a/tests/files/modules/multirules/__init__.py
+++ b/tests/files/modules/multirules/__init__.py
@@ -1,0 +1,2 @@
+from .multistring import MultiString
+from .multirule import MultiRule

--- a/tests/files/modules/multirules/multirule.py
+++ b/tests/files/modules/multirules/multirule.py
@@ -1,0 +1,25 @@
+from malduck import Extractor
+
+
+class MultiRule(Extractor):
+    family = "multistring_v2"
+    yara_rules = "MultiString", "MultiString_v2"
+
+    @Extractor.rule("MultiString")
+    def multi_string_rule(self, p, matches):
+        return (
+            "first_string" not in matches
+            and "third_string" in matches
+            and matches.third_string[0].offset == 0
+        )
+
+    @Extractor.rule
+    def MultiString_v2(self, p, matches):
+        if matches.rule != "MultiString_v2":
+            return {
+                "matched": ["something wrong happened"]
+            }
+        if matches.var_string[0].content == b"a0a1b2b3c4c5d6d7e8":
+            return {
+                "matched": ["v2"]
+            }

--- a/tests/files/modules/multirules/multirules.yar
+++ b/tests/files/modules/multirules/multirules.yar
@@ -1,0 +1,19 @@
+rule MultiString
+{
+    strings:
+        $first_string1 = "fIrSt string"
+        $first_string2 = "FiRsT string"
+        $second_string = "second string" nocase
+        $third_string = "ThIrD string"
+    condition:
+        any of them
+}
+
+rule MultiString_v2
+{
+    strings:
+        $var_string = { 61 30 61 31 62 [2-6] 63 (65 | 35) 64 36 64 37 65 38 }
+        $fourth_string = "FoUrTh string"
+    condition:
+        all of them
+}

--- a/tests/files/modules/multirules/multistring.py
+++ b/tests/files/modules/multirules/multistring.py
@@ -1,0 +1,21 @@
+from malduck import Extractor
+
+
+class MultiString(Extractor):
+    family = "multistring"
+    yara_rules = "MultiString",
+
+    @Extractor.string("first_string", "second_string")
+    def first_strings(self, p, addr, match):
+        if p.readv(addr, len(match.content)) == match.content:
+            return {
+                "first": [match.content]
+            }
+
+    @Extractor.weak
+    @Extractor.string
+    def third_string(self, p, addr, match):
+        if p.readv(addr, len(match.content)) == match.content:
+            return {
+                "third": [match.content]
+            }

--- a/tests/files/yara/digit_group.yar
+++ b/tests/files/yara/digit_group.yar
@@ -1,0 +1,10 @@
+rule DigitGroup {
+    strings:
+        $grouped_00 = "digit_group_confirmed0"
+        $grouped_1  = "1digit_group_confirmed"
+        $grouped2   = "digit_group_confirmed02"
+        $grouped03  = "31digit_group_confirmed"
+        $ungrouped  = "digit_group_unconfirmed"
+    condition:
+        any of them
+}

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -61,3 +61,22 @@ def test_weaky():
         "weak": True,
         "weaky": True
     }]
+
+
+def test_multirules():
+    modules = ExtractorModules("tests/files/modules")
+    multistring = procmem(b"FiRsT string fIrSt string"
+                          b"SeCoNd string sEcOnD string"
+                          b"ThIrD string tHiRd string")
+    assert multistring.extract(modules) == [{
+        'family': 'multistring',
+        'first': ['FiRsT string', 'fIrSt string', 'SeCoNd string', 'sEcOnD string'],
+        'third': ['ThIrD string']
+    }]
+
+    multistring_v2 = procmem(b"ThIrD stringa0a1b2b3c4c5d6d7e8e9FoUrTh string")
+    assert multistring_v2.extract(modules) == [{
+        'family': 'multistring_v2',
+        'matched': ['v2'],
+        'third': ['ThIrD string']
+    }]

--- a/tests/test_yara.py
+++ b/tests/test_yara.py
@@ -1,6 +1,6 @@
 import os
 
-from malduck import Yara, YaraString
+from malduck import Yara, YaraString, YaraStringMatch
 from malduck.procmem import Region, ProcessMemory
 
 
@@ -21,16 +21,16 @@ def test_yara_match():
     assert "r" in match.keys()
 
     assert sorted(match.r.keys()) == ["program", "program1"]
-    assert match.r["program"] == [12]
-    assert match.r["program1"] == [12]
+    assert match.r.get_offsets("program") == [12]
+    assert match.r.get_offsets("program1") == [12]
 
     match = yara.match(data=b"margorP\x90\x90\x90\xffProgram")
     assert match
     assert sorted(match.r.keys()) == ["program", "program2", "program3", "program4"]
-    assert sorted(match.r["program"]) == [
-        match.r.program3[0],
-        match.r.program4[0],
-        match.r.program2[0]]
+    assert sorted(match.r.get_offsets("program")) == [
+        match.r.program3[0].hit,
+        match.r.program4[0].hit,
+        match.r.program2[0].hit]
 
 
 def test_yara_escaping():
@@ -52,12 +52,24 @@ def test_yara_dirs_and_files():
     match = all_rules.match(filepath=os.path.join(local_path, "calc.exe"))
     # FourSectionPE doesn't have any strings
     assert sorted(match.keys()) == ["Calc"]
-    assert match.Calc.calc == [0xb996c]
+    assert match.Calc.calc == [
+        YaraStringMatch(identifier='calc', hit=0xb996c, content=b'C\x00A\x00L\x00C\x00.\x00E\x00X\x00E\x00')
+    ]
 
     match = all_rules.match(filepath=os.path.join(local_path, "dummy.dmp"))
     assert sorted(match.keys()) == ["DummyRoachRule"]
     assert sorted(match.DummyRoachRule.keys()) == ["region_bc", "region_bc1", "region_bc2"]
-    assert sorted(match.DummyRoachRule.region_bc) == [0x1014, 0x302c]
+    # Strings must be ordered by hits
+    assert match.DummyRoachRule.region_bc == [
+        YaraStringMatch(identifier='region_bc2',
+                        hit=0x1014,
+                        content=b'AAAA\x00\x10AA\x00\x00\x00\x00\x00 \x00\x00*\x00\x00\x00'
+                                b'+\x00\x00\x00\x02\x00\x00\x00BBBB'),
+        YaraStringMatch(identifier='region_bc1',
+                        hit=0x302c,
+                        content=b'BBBB\x00\x00BB\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00'
+                                b'\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00CCCC'),
+    ]
 
     match = inner_rules.match(filepath=os.path.join(local_path, "calc.exe"))
     assert match
@@ -101,11 +113,11 @@ def test_procmem_yara():
     assert matchv
     assert set(matchp.regions.keys()).difference(set(matchv.regions.keys())) == {"c_and_d"}
 
-    assert [matchv.regions.a_and_b[0], matchv.regions.b_and_c[0]] == [0x400fc0, 0x401fc0]
-    assert matchv.regions.a_series == list(range(0x400000, 0x401000 - 63))
-    assert matchv.regions.b_series == list(range(0x401000, 0x402000 - 63))
-    assert matchv.regions.c_series == list(range(0x402000, 0x403000 - 63))
-    assert matchv.regions.d_series == list(range(0x410000, 0x411000 - 63))
+    assert [matchv.regions.a_and_b[0].hit, matchv.regions.b_and_c[0].hit] == [0x400fc0, 0x401fc0]
+    assert matchv.regions.get_offsets("a_series") == list(range(0x400000, 0x401000 - 63))
+    assert matchv.regions.get_offsets("b_series") == list(range(0x401000, 0x402000 - 63))
+    assert matchv.regions.get_offsets("c_series") == list(range(0x402000, 0x403000 - 63))
+    assert matchv.regions.get_offsets("d_series") == list(range(0x410000, 0x411000 - 63))
     assert matchv.regions.get("a_series")
     assert not matchv.regions.get("e_series")
 

--- a/tests/test_yara.py
+++ b/tests/test_yara.py
@@ -108,3 +108,27 @@ def test_procmem_yara():
     assert matchv.regions.d_series == list(range(0x410000, 0x411000 - 63))
     assert matchv.regions.get("a_series")
     assert not matchv.regions.get("e_series")
+
+
+def test_digit_group_yara():
+    local_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "files", "yara")
+    ruleset = Yara.from_dir(local_path)
+
+    p = ProcessMemory(b"531digit_group_confirmed024")
+    match_all = p.yarap(ruleset, extended=True)["DigitGroup"]
+    match_suffix = p.yarap(ruleset, offset=3, extended=True)["DigitGroup"]
+    match_prefix = p.yarap(ruleset, length=24, extended=True)["DigitGroup"]
+
+    assert (
+        sorted(['grouped03', 'grouped_1', 'grouped_00', 'grouped2']) ==
+        sorted([match.identifier for match in match_all["grouped"]])
+    )
+    assert "ungrouped" not in match_all
+    assert (
+        sorted(['grouped_00', 'grouped2']) ==
+        sorted([match.identifier for match in match_suffix["grouped"]])
+    )
+    assert (
+        sorted(['grouped03', 'grouped_1']) ==
+        sorted([match.identifier for match in match_prefix["grouped"]])
+    )


### PR DESCRIPTION
- Extended version of `@Extractor.extractor` methods called `@Extractor.string`
```python
class Evil(Extractor):
    yara_rules = ("evil", "weird")
    family = "evil"
    ...

    @Extractor.string("accepts", "multiple", "strings")
    def hello_evil(self, p: ProcessMemory, addr: int, match: YaraStringMatch):
        # Accepts multiple identifiers, called by $accepts, $multiple and $strings hit
        if match.identifier == "accepts":
            # Allows to get both hit VA and matched content
            return {"hello_message": match.content}
```

- `malduck.yara` extended structures: `YaraRulesetMatch`, `YaraRuleMatch`, `YaraStringMatch`
- structures offering legacy offset-only interface: `YaraRulesetOffsets` (`YaraMatches`), `YaraRuleOffsets` (`YaraMatch`)
- both extended and legacy versions are available via `ProcessMemory.yarap/v` and `Yara.match` methods. We can choose new structures via additional `extended=True` argument, which is set to False by default.


Other changes:
- `YaraRulesetMatch.remap` doesn't mutate the object, returns remapped object instead
- Refactor of Yara match mapping machinery

closes #5 

Missing parts:
- [x] Documentation
- [x] Tests for new features