### PR TITLE
Fix function formatter print

### DIFF
--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -441,7 +441,7 @@ class Extractor:
                         self.__class__.__name__,
                         method_name,
                         identifier,
-                        string_match,
+                        string_match.offset,
                     )
                     method(self, p, string_match.offset)
                 except Exception as exc:


### PR DESCRIPTION
This was introduced when changing the match type from `int` to `YaraStringMatch`

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.7/logging/__init__.py", line 1025, in emit
    msg = self.format(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 869, in format
    return fmt.format(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 608, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.7/logging/__init__.py", line 369, in getMessage
    msg = msg % self.args
TypeError: %x format: an integer is required, not YaraStringMatch
Call stack:
  File "/home/michal/work/malduck/venv/bin/malduck", line 33, in <module>
    sys.exit(load_entry_point('malduck', 'console_scripts', 'malduck')())
  File "/home/michal/work/malduck/venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/michal/work/malduck/venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/michal/work/malduck/venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/michal/work/malduck/venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/michal/work/malduck/venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/michal/work/malduck/venv/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/michal/work/malduck/malduck/main.py", line 124, in extract
    extract_manager.push_file(file_path, base=base)
  File "/home/michal/work/malduck/malduck/extractor/extract_manager.py", line 191, in push_file
    return self.push_procmem(p, rip_binaries=True)
  File "/home/michal/work/malduck/malduck/extractor/extract_manager.py", line 257, in push_procmem
    found_family = extract_config(binary)
  File "/home/michal/work/malduck/malduck/extractor/extract_manager.py", line 243, in extract_config
    extractor.push_procmem(procmem, _matches=matches.remap(procmem.p2v))
  File "/home/michal/work/malduck/malduck/extractor/extract_manager.py", line 329, in push_procmem
    extractor.handle_match(p, matches[rule])
  File "/home/michal/work/malduck/malduck/extractor/extractor.py", line 446, in handle_match
    string_match,
Message: 'Trying %s.%s for %s@%x'
```