### PR TITLE
CI: Don't generate universal wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Build package
       run: |
         pip3 install setuptools wheel
-        python3 setup.py bdist_wheel --universal
+        python3 setup.py bdist_wheel
     - name: Publish to PyPi
       uses: pypa/gh-action-pypi-publish@v1.3.0
       with:


### PR DESCRIPTION
Python 2 support is dropped, it's unnecessary to generate universal wheel package.

- https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels
- https://packaging.python.org/guides/distributing-packages-using-setuptools/#pure-python-wheels