### PR TITLE
Fix premature file/mmap closing

### DIFF
--- a/malduck/procmem/procmempe.py
+++ b/malduck/procmem/procmempe.py
@@ -47,12 +47,13 @@ class ProcessMemoryPE(ProcessMemoryBinary):
     def _reload_as_image(self) -> None:
         # Load PE data from imgbase offset
         pe = self._pe_direct_load(fast_load=False)
-        # Reset regions
-        if self.mapped_memory:
-            self.close()
+        # If mmap: close all descriptors or
+        # nullify references if mmap is not owned by current object
+        self.close()
+        # Set memory to the pe.data buffer
         self.memory = bytearray(pe.data)
         self.imgbase = pe.optional_header.ImageBase
-
+        # Reset regions
         self.regions = [Region(self.imgbase, pe.headers_size, 0, 0, 0, 0)]
         # Load image sections
         for section in pe.sections:


### PR DESCRIPTION
In addition to https://github.com/CERT-Polska/malduck/pull/37

There are plenty of methods of ProcessMemory object initialization:
- `mmap` passed via constructor (not owned by constructed object and should be closed by mmap creator)
- `procmem.from_file` - opens file and creates mmap object, both things should be closed by `close()` method
- `procmem.from_memory` derives mmap object from original procmem, mmap is still owned by original object.

`self.opened_file` indicates that mapped file was opened by `from_file` method.