### PR TITLE
Add missing procmempe in docs

### DIFF
--- a/malduck/procmem/procmem.py
+++ b/malduck/procmem/procmem.py
@@ -55,7 +55,7 @@ class ProcessMemory:
 
     .. code-block:: python
 
-        from malduck import procmem
+        from malduck import procmem, procmempe
 
         with open("notepad.exe_400000.bin", "rb") as f:
             payload = f.read()


### PR DESCRIPTION
In the fixed example, `procmempe.from_memory(p)` was used without that `procmempe` was imported