### PR TITLE
Fix idamem usage, add MemoryBuffer metaclass

### DIFF
--- a/malduck/procmem/__init__.py
+++ b/malduck/procmem/__init__.py
@@ -1,4 +1,4 @@
-from .procmem import ProcessMemory, procmem
+from .procmem import ProcessMemory, procmem, MemoryBuffer
 from .procmempe import ProcessMemoryPE, procmempe
 from .procmemelf import ProcessMemoryELF, procmemelf
 from .cuckoomem import CuckooProcessMemory, cuckoomem
@@ -20,6 +20,7 @@ __all__ = [
     "procmem",
     "ProcessMemoryPE",
     "procmempe",
+    "MemoryBuffer",
     "ProcessMemoryELF",
     "procmemelf",
     "CuckooProcessMemory",

--- a/malduck/procmem/idamem.py
+++ b/malduck/procmem/idamem.py
@@ -1,4 +1,4 @@
-from .procmem import ProcessMemory
+from .procmem import ProcessMemory, MemoryBuffer
 from .region import Region
 
 try:
@@ -13,7 +13,7 @@ except ImportError:
 __all__ = ["IDAProcessMemory", "idamem"]
 
 
-class IDAVM(object):
+class IDAVM(MemoryBuffer):
     def __init__(self, idamem):
         self.idamem = idamem
 

--- a/malduck/procmem/procmem.py
+++ b/malduck/procmem/procmem.py
@@ -12,7 +12,7 @@ from ..yara import Yara, YaraString
 __all__ = ["ProcessMemory", "procmem"]
 
 
-class MemoryBuffer(object):
+class MemoryBuffer:
     def __setitem__(self, item, value):
         raise NotImplementedError("__setitem__ not implemented")
 

--- a/malduck/procmem/procmem.py
+++ b/malduck/procmem/procmem.py
@@ -11,7 +11,19 @@ from ..yara import Yara, YaraString
 
 __all__ = ["ProcessMemory", "procmem"]
 
-ProcessMemoryBuffer = Union[bytes, bytearray, mmap.mmap]
+
+class MemoryBuffer(object):
+    def __setitem__(self, item, value):
+        raise NotImplementedError("__setitem__ not implemented")
+
+    def __getitem__(self, item):
+        raise NotImplementedError("__getitem__ not implemented")
+
+    def __len__(self):
+        raise NotImplementedError("__len__ not implemented")
+
+
+ProcessMemoryBuffer = Union[bytes, bytearray, mmap.mmap, MemoryBuffer]
 
 
 class ProcessMemory:
@@ -87,9 +99,11 @@ class ProcessMemory:
             self.memory = bytearray(buf)
         elif isinstance(buf, bytearray):
             self.memory = buf
+        elif isinstance(buf, MemoryBuffer):
+            self.memory = buf
         else:
             raise TypeError(
-                "Wrong buffer type - must be bytes, bytearray or mmap object"
+                "Wrong buffer type - must be bytes, bytearray, mmap object or MemoryBuffer"
             )
 
         self.imgbase = base

--- a/malduck/procmem/procmem.pyi
+++ b/malduck/procmem/procmem.pyi
@@ -29,7 +29,7 @@ class MemoryBuffer(object):
     def __getitem__(self, item: Union[int, slice]): ...
     def __len__(self) -> int: ...
 
-ProcessMemoryBuffer = Union[bytes, bytearray, mmap.mmap]
+ProcessMemoryBuffer = Union[bytes, bytearray, mmap.mmap, MemoryBuffer]
 T = TypeVar("T", bound="ProcessMemory")
 
 procmem: Type["ProcessMemory"]

--- a/malduck/procmem/procmem.pyi
+++ b/malduck/procmem/procmem.pyi
@@ -24,6 +24,11 @@ from ..yara import Yara, YaraRulesetMatch, YaraRulesetOffsets
 
 from ..ints import IntType
 
+class MemoryBuffer(object):
+    def __setitem__(self, item: Union[int, slice], value: Union[int, slice]): ...
+    def __getitem__(self, item: Union[int, slice]): ...
+    def __len__(self) -> int: ...
+
 ProcessMemoryBuffer = Union[bytes, bytearray, mmap.mmap]
 T = TypeVar("T", bound="ProcessMemory")
 


### PR DESCRIPTION
During the large code migration in #16 an unintended regression was introduced that dropped support for custom memory objects in procmem's constructor: https://github.com/CERT-Polska/malduck/commit/4bbf43add1ea20e278e2fe8cec5577a5e0869803#diff-767505ff127f0f90757a6e16449a659bR84

As a result, starting from 4.0.0, attempts to initiate `idamem` object in IDAPython fail: 

```python
Python>from malduck import idamem
Python>idamem()
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/malduck/procmem/idamem.py", line 67, in __init__
    super().__init__(IDAVM(self), regions=regions)
  File "/usr/local/lib/python3.6/dist-packages/malduck/procmem/procmem.py", line 92, in __init__
    "Wrong buffer type - must be bytes, bytearray or mmap object"
```

This pull request fixes this issue by introducing a base class for custom memory object implementations called `MemoryBuffer`