### PR TITLE
Use utf16z in the docs for wide_string

### DIFF
--- a/malduck/procmem/idamem.py
+++ b/malduck/procmem/idamem.py
@@ -64,7 +64,7 @@ class IDAProcessMemory(ProcessMemory):
 
         ida = idamem()
         decrypted_data = xor(b"KEYZ", ida.readv(0x0040D320, 128))
-        some_wide_string = ida.utf16z(0x402010).decode("utf-16")
+        some_wide_string = ida.utf16z(0x402010).decode("utf-8")
     """
 
     def __init__(self):

--- a/malduck/procmem/idamem.py
+++ b/malduck/procmem/idamem.py
@@ -64,7 +64,7 @@ class IDAProcessMemory(ProcessMemory):
 
         ida = idamem()
         decrypted_data = xor(b"KEYZ", ida.readv(0x0040D320, 128))
-        some_wide_string = ida.asciiz(0x402010).decode("utf-16")
+        some_wide_string = ida.utf16z(0x402010).decode("utf-16")
     """
 
     def __init__(self):


### PR DESCRIPTION
In the procmem [docs](https://malduck.readthedocs.io/en/latest/procmem.html?highlight=wide#malduck.procmem.idamem.IDAProcessMemory) there is a usage of `asciiz` instead of `utf16z`

```
some_wide_string = ida.asciiz(0x402010).decode("utf-16")
```
