### PR TITLE
Handle invalid PE's in resource getter

### DIFF
--- a/malduck/pe.py
+++ b/malduck/pe.py
@@ -308,6 +308,11 @@ class PE(object):
         def type_int(e1, e2, e3):
             return e1.id == type_id
 
+        # Broken PE files will not have this directory and it's better to return no value
+        # than to throw a meaningless exception
+        if not hasattr(self.pe, "DIRECTORY_ENTRY_RESOURCE"):
+            return
+
         if isinstance(name, str):
             name = name.encode()
 


### PR DESCRIPTION
Since detecting invalid PE's is pretty hard (believe me, we tried) this fix should stop those annoying FastPE error messages from popping up (see #44 for details)

Closes #44 