### PR TITLE
Bump mypy and revert camellia type checks

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8==3.8.3 pytest==5.4.1 black==19.10b0 mypy==0.782 mypy-extensions==0.4.3
+        pip install flake8==3.8.3 pytest==5.4.1 black==19.10b0 mypy==0.800 mypy-extensions==0.4.3
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/malduck/extractor/loaders.py
+++ b/malduck/extractor/loaders.py
@@ -56,7 +56,9 @@ def load_modules(
         if module_name in modules:
             log.warning("Module collision - %s overridden", module_name)
         try:
-            modules[module_name] = import_module_by_finder(cast(PathEntryFinder, finder), module_name)
+            modules[module_name] = import_module_by_finder(
+                cast(PathEntryFinder, finder), module_name
+            )
         except Exception as exc:
             if onerror:
                 onerror(exc, module_name)

--- a/malduck/extractor/loaders.py
+++ b/malduck/extractor/loaders.py
@@ -3,15 +3,14 @@ import logging
 import pkgutil
 import sys
 
-from importlib.abc import FileLoader
-from importlib.machinery import FileFinder
+from importlib.abc import FileLoader, PathEntryFinder
 
 from typing import Callable, Optional, Any, Dict, cast
 
 log = logging.getLogger(__name__)
 
 
-def import_module_by_finder(finder: FileFinder, module_name: str) -> Any:
+def import_module_by_finder(finder: PathEntryFinder, module_name: str) -> Any:
     """
     Imports module from arbitrary path using importer returned by pkgutil.iter_modules
     """
@@ -57,7 +56,7 @@ def load_modules(
         if module_name in modules:
             log.warning("Module collision - %s overridden", module_name)
         try:
-            modules[module_name] = import_module_by_finder(finder, module_name)
+            modules[module_name] = import_module_by_finder(cast(PathEntryFinder, finder), module_name)
         except Exception as exc:
             if onerror:
                 onerror(exc, module_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,3 @@ ignore_missing_imports = True
 
 [mypy-ida_bytes.*]
 ignore_missing_imports = True
-
-[mypy-malduck.crypto.camellia]
-ignore_errors = True


### PR DESCRIPTION
The fix for typo in pycryptodome camellia is now live and we can reenable mypy checks.
This also fixes a resulting error that appeared because types for `pkgutil.iter_modules` have been made more precise: https://github.com/python/typeshed/commit/8642d2aa97e6fbb87c06c169c72a0ebf8d1f42f1#diff-e116aacd70a29ba95251191d086f73c4b803499ebc85de2c4a775db4ff3c41b6L18

Closes #52 