### PR TITLE
Fix Bigint.pack for odd-length hex integers

### DIFF
--- a/malduck/string/bin.py
+++ b/malduck/string/bin.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 Jurriaan Bremer.
 # This file is part of Roach - https://github.com/jbremer/roach.
 # See the file 'docs/LICENSE.txt' for copying permission.
+import math
 import struct
 import warnings
 
@@ -89,10 +90,7 @@ class Bigint:
         :type size: bytes, optional
         :rtype: bytes
         """
-        packed = unhex(f"{other:x}")[::-1]
-        if size:
-            packed = packed[:size].ljust(size, b"\x00")
-        return packed
+        return self.pack_be(other, size)[::-1]
 
     def unpack_be(self, other: bytes, size: Optional[int] = None) -> int:
         """
@@ -123,10 +121,9 @@ class Bigint:
         :type size: bytes, optional
         :rtype: bytes
         """
-        packed = unhex(f"{other:x}")
-        if size:
-            packed = packed[:size].rjust(size, b"\x00")
-        return packed
+        if size is None:
+            size = math.ceil(other.bit_length() / 8)
+        return unhex(f"{other:0{size * 2}x}")
 
     def __call__(self, s, bitsize):
         warnings.warn(

--- a/malduck/string/bin.py
+++ b/malduck/string/bin.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2018 Jurriaan Bremer.
 # This file is part of Roach - https://github.com/jbremer/roach.
 # See the file 'docs/LICENSE.txt' for copying permission.
-import math
 import struct
 import warnings
 
@@ -90,7 +89,9 @@ class Bigint:
         :type size: bytes, optional
         :rtype: bytes
         """
-        return self.pack_be(other, size)[::-1]
+        if size is None:
+            size = (other.bit_length() + 7) // 8
+        return other.to_bytes(size, byteorder="little")
 
     def unpack_be(self, other: bytes, size: Optional[int] = None) -> int:
         """
@@ -122,8 +123,8 @@ class Bigint:
         :rtype: bytes
         """
         if size is None:
-            size = math.ceil(other.bit_length() / 8)
-        return unhex(f"{other:0{size * 2}x}")
+            size = (other.bit_length() + 7) // 8
+        return other.to_bytes(size, byteorder="big")
 
     def __call__(self, s, bitsize):
         warnings.warn(

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -120,6 +120,11 @@ def test_bigint():
     assert bigint.unpack_be(b"ABCDE", 4) == 0x41424344
     assert bigint.pack_be(0x41424344, 8) == b"\x00\x00\x00\x00ABCD"
 
+    assert bigint.pack(1) == b"\x01"
+    assert bigint.pack_be(1) == b"\x01"
+    assert bigint.pack(1234) == b"\xd2\x04"
+    assert bigint.pack_be(1234) == b"\x04\xd2"
+
 
 def test_pack():
     assert pack(

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -124,6 +124,8 @@ def test_bigint():
     assert bigint.pack_be(1) == b"\x01"
     assert bigint.pack(1234) == b"\xd2\x04"
     assert bigint.pack_be(1234) == b"\x04\xd2"
+    assert bigint.unpack(b"\xd2\x04") == 1234
+    assert bigint.unpack_be(b"\x04\xd2") == 1234
 
 
 def test_pack():


### PR DESCRIPTION
This fixes  the following error when you bigint.pack() an integer that has an odd-length hex string, such as 1 or 1234 (0x4d2).

```
    def unhex(s: Union[str, bytes]) -> bytes:
>       return binascii.unhexlify(s)
E       binascii.Error: Odd-length string
```