### PR TITLE
Fix Aplib decompression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 malduck.egg-info/
 ven*/
 .mypy_cache/
+.DS_Store

--- a/malduck/compression/aplib.py
+++ b/malduck/compression/aplib.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from binascii import crc32
 
 from .components.aplib import APLib
 
@@ -37,24 +38,30 @@ class aPLib:
         orig_crc = None
         strict = not headerless
 
-        if buf.startswith(b'AP32') and len(buf) >= 24:
+        if buf.startswith(b"AP32") and len(buf) >= 24:
             # buf has an aPLib header
-            header_size, packed_size, packed_crc, orig_size, orig_crc = struct.unpack_from('=IIIII', buf, 4)
+            (
+                header_size,
+                packed_size,
+                packed_crc,
+                orig_size,
+                orig_crc,
+            ) = struct.unpack_from("=IIIII", buf, 4)
             buf = buf[header_size : header_size + packed_size]
 
         if strict:
             if packed_size is not None and packed_size != len(buf):
-                raise RuntimeError('Packed buf size is incorrect')
+                raise RuntimeError("Packed buf size is incorrect")
             if packed_crc is not None and packed_crc != crc32(buf):
-                raise RuntimeError('Packed buf checksum is incorrect')
+                raise RuntimeError("Packed buf checksum is incorrect")
 
         result = APLib(buf, strict=strict).depack()
 
         if strict:
             if orig_size is not None and orig_size != len(result):
-                raise RuntimeError('Unpacked buf size is incorrect')
+                raise RuntimeError("Unpacked buf size is incorrect")
             if orig_crc is not None and orig_crc != crc32(result):
-                raise RuntimeError('Unpacked buf checksum is incorrect')
+                raise RuntimeError("Unpacked buf checksum is incorrect")
 
         return result
 

--- a/malduck/compression/aplib.py
+++ b/malduck/compression/aplib.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from .components.aplib import ap_depack
+from .components.aplib import APLib
 
 import logging
 import struct
@@ -30,16 +30,33 @@ class aPLib:
     :rtype: bytes
     """
 
-    def decompress(self, buf: bytes, headerless: bool = False) -> Optional[bytes]:
-        try:
-            # Trim header
-            if not headerless and buf.startswith(b"AP32"):
-                hdr_length = struct.unpack_from("<I", buf, 4)[0]
-                buf = buf[hdr_length:]
-            # Decompress aPLib
-            return bytes(ap_depack(buf))
-        except Exception:
-            return None
+    def decompress(self, buf: bytes, headerless: bool = True) -> Optional[bytes]:
+        packed_size = None
+        packed_crc = None
+        orig_size = None
+        orig_crc = None
+        strict = not headerless
+
+        if buf.startswith(b'AP32') and len(buf) >= 24:
+            # buf has an aPLib header
+            header_size, packed_size, packed_crc, orig_size, orig_crc = struct.unpack_from('=IIIII', buf, 4)
+            buf = buf[header_size : header_size + packed_size]
+
+        if strict:
+            if packed_size is not None and packed_size != len(buf):
+                raise RuntimeError('Packed buf size is incorrect')
+            if packed_crc is not None and packed_crc != crc32(buf):
+                raise RuntimeError('Packed buf checksum is incorrect')
+
+        result = APLib(buf, strict=strict).depack()
+
+        if strict:
+            if orig_size is not None and orig_size != len(result):
+                raise RuntimeError('Unpacked buf size is incorrect')
+            if orig_crc is not None and orig_crc != crc32(result):
+                raise RuntimeError('Unpacked buf checksum is incorrect')
+
+        return result
 
     __call__ = decompress
 

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -9,7 +9,7 @@ import struct
 from binascii import crc32
 from io import BytesIO
 
-__all__ = ['APLib', 'decompress']
+__all__ = ['APLib']
 __version__ = '0.6'
 __author__ = 'Sandor Nemes'
 
@@ -136,7 +136,7 @@ class APLib(object):
 def main():
     # self-test
     data = b'T\x00he quick\xecb\x0erown\xcef\xaex\x80jumps\xed\xe4veur`t?lazy\xead\xfeg\xc0\x00'
-    assert decompress(data) == b'The quick brown fox jumps over the lazy dog'
+    assert APLib(data).depack() == b'The quick brown fox jumps over the lazy dog'
 
 
 if __name__ == '__main__':

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -25,7 +25,7 @@ class APLib(object):
         self.bitcount = 0
         self.strict = bool(strict)
 
-    def getbit(self):
+    def getbit(self) -> int:
         # check if tag is empty
         self.bitcount -= 1
         if self.bitcount < 0:

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -5,18 +5,16 @@ Adapted from the original C source code from http://ibsensoftware.com/files/aPLi
 Approximately 20 times faster than other Python implementations.
 Compatible with both Python 2 and 3.
 """
-import struct
-from binascii import crc32
 from io import BytesIO
 
-__all__ = ['APLib']
-__version__ = '0.6'
-__author__ = 'Sandor Nemes'
+__all__ = ["APLib"]
+__version__ = "0.6"
+__author__ = "Sandor Nemes"
 
 
 class APLib(object):
 
-    __slots__ = 'source', 'destination', 'tag', 'bitcount', 'strict'
+    __slots__ = "source", "destination", "tag", "bitcount", "strict"
 
     def __init__(self, source: bytes, strict: bool = True) -> None:
         self.source = BytesIO(source)
@@ -126,7 +124,7 @@ class APLib(object):
 
         except (TypeError, IndexError):
             if self.strict:
-                raise RuntimeError('aPLib decompression error')
+                raise RuntimeError("aPLib decompression error")
 
         return bytes(self.destination)
 
@@ -135,8 +133,8 @@ class APLib(object):
 
 def main():
     # self-test
-    data = b'T\x00he quick\xecb\x0erown\xcef\xaex\x80jumps\xed\xe4veur`t?lazy\xead\xfeg\xc0\x00'
-    assert APLib(data).depack() == b'The quick brown fox jumps over the lazy dog'
+    data = b"T\x00he quick\xecb\x0erown\xcef\xaex\x80jumps\xed\xe4veur`t?lazy\xead\xfeg\xc0\x00"
+    assert APLib(data).depack() == b"The quick brown fox jumps over the lazy dog"
 
 
 if __name__ == '__main__':

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -50,7 +50,7 @@ class APLib(object):
 
         return result
 
-    def depack(self):
+    def depack(self) -> bytes:
         r0 = -1
         lwm = 0
         done = False

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -138,5 +138,5 @@ def main():
     assert APLib(data).depack() == b"The quick brown fox jumps over the lazy dog"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -18,7 +18,7 @@ class APLib(object):
 
     __slots__ = 'source', 'destination', 'tag', 'bitcount', 'strict'
 
-    def __init__(self, source, strict=True):
+    def __init__(self, source: bytes, strict: bool = True) -> None:
         self.source = BytesIO(source)
         self.destination = bytearray()
         self.tag = 0

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -1,132 +1,172 @@
-# -*- coding: utf-8 -*-
-"""
-aplib.py by snemes from https://github.com/snemes/aplib
+#!/usr/bin/env python3
+"""A pure Python module for decompressing aPLib compressed data
 
-A pure Python module for decompressing aPLib compressed data.
 Adapted from the original C source code from http://ibsensoftware.com/files/aPLib-1.1.1.zip
-Approximately ~20 times faster than the other Python implementations.
+Approximately 20 times faster than other Python implementations.
+Compatible with both Python 2 and 3.
 """
+import struct
+from binascii import crc32
 from io import BytesIO
 
-__all__ = ["ap_depack"]
-__version__ = "0.3"
-__author__ = "Sandor Nemes"
+__all__ = ['APLib', 'decompress']
+__version__ = '0.6'
+__author__ = 'Sandor Nemes'
 
 
-class APDSTATE:
-    """internal data structure"""
+class APLib(object):
 
-    def __init__(self, source: bytes) -> None:
+    __slots__ = 'source', 'destination', 'tag', 'bitcount', 'strict'
+
+    def __init__(self, source, strict=True):
         self.source = BytesIO(source)
         self.destination = bytearray()
         self.tag = 0
         self.bitcount = 0
+        self.strict = bool(strict)
+
+    def getbit(self):
+        # check if tag is empty
+        self.bitcount -= 1
+        if self.bitcount < 0:
+            # load next tag
+            self.tag = ord(self.source.read(1))
+            self.bitcount = 7
+
+        # shift bit out of tag
+        bit = self.tag >> 7 & 1
+        self.tag <<= 1
+
+        return bit
+
+    def getgamma(self):
+        result = 1
+
+        # input gamma2-encoded bits
+        while True:
+            result = (result << 1) + self.getbit()
+            if not self.getbit():
+                break
+
+        return result
+
+    def depack(self):
+        r0 = -1
+        lwm = 0
+        done = False
+
+        try:
+
+            # first byte verbatim
+            self.destination += self.source.read(1)
+
+            # main decompression loop
+            while not done:
+                if self.getbit():
+                    if self.getbit():
+                        if self.getbit():
+                            offs = 0
+                            for _ in range(4):
+                                offs = (offs << 1) + self.getbit()
+
+                            if offs:
+                                self.destination.append(self.destination[-offs])
+                            else:
+                                self.destination.append(0)
+
+                            lwm = 0
+                        else:
+                            offs = ord(self.source.read(1))
+                            length = 2 + (offs & 1)
+                            offs >>= 1
+
+                            if offs:
+                                for _ in range(length):
+                                    self.destination.append(self.destination[-offs])
+                            else:
+                                done = True
+
+                            r0 = offs
+                            lwm = 1
+                    else:
+                        offs = self.getgamma()
+
+                        if lwm == 0 and offs == 2:
+                            offs = r0
+                            length = self.getgamma()
+
+                            for _ in range(length):
+                                self.destination.append(self.destination[-offs])
+                        else:
+                            if lwm == 0:
+                                offs -= 3
+                            else:
+                                offs -= 2
+
+                            offs <<= 8
+                            offs += ord(self.source.read(1))
+                            length = self.getgamma()
+
+                            if offs >= 32000:
+                                length += 1
+                            if offs >= 1280:
+                                length += 1
+                            if offs < 128:
+                                length += 2
+
+                            for _ in range(length):
+                                self.destination.append(self.destination[-offs])
+
+                            r0 = offs
+
+                        lwm = 1
+                else:
+                    self.destination += self.source.read(1)
+                    lwm = 0
+
+        except (TypeError, IndexError):
+            if self.strict:
+                raise RuntimeError('aPLib decompression error')
+
+        return bytes(self.destination)
+
+    def pack(self):
+        raise NotImplementedError
 
 
-def ap_getbit(ud: APDSTATE) -> int:
-    # check if tag is empty
-    ud.bitcount -= 1
-    if ud.bitcount < 0:
-        # load next tag
-        ud.tag = ord(ud.source.read(1))
-        ud.bitcount = 7
+def decompress(data, strict=False):
+    packed_size = None
+    packed_crc = None
+    orig_size = None
+    orig_crc = None
 
-    # shift bit out of tag
-    bit = ud.tag >> 7 & 0x01
-    ud.tag <<= 1
+    if data.startswith(b'AP32') and len(data) >= 24:
+        # data has an aPLib header
+        header_size, packed_size, packed_crc, orig_size, orig_crc = struct.unpack_from('=IIIII', data, 4)
+        data = data[header_size : header_size + packed_size]
 
-    return bit
+    if strict:
+        if packed_size is not None and packed_size != len(data):
+            raise RuntimeError('Packed data size is incorrect')
+        if packed_crc is not None and packed_crc != crc32(data):
+            raise RuntimeError('Packed data checksum is incorrect')
 
+    result = APLib(data, strict=strict).depack()
 
-def ap_getgamma(ud: APDSTATE) -> int:
-    result = 1
-
-    # input gamma2-encoded bits
-    while True:
-        result = (result << 1) + ap_getbit(ud)
-        if not ap_getbit(ud):
-            break
+    if strict:
+        if orig_size is not None and orig_size != len(result):
+            raise RuntimeError('Unpacked data size is incorrect')
+        if orig_crc is not None and orig_crc != crc32(result):
+            raise RuntimeError('Unpacked data checksum is incorrect')
 
     return result
 
 
-def ap_depack(source: bytes) -> bytearray:
-    ud = APDSTATE(source)
+def main():
+    # self-test
+    data = b'T\x00he quick\xecb\x0erown\xcef\xaex\x80jumps\xed\xe4veur`t?lazy\xead\xfeg\xc0\x00'
+    assert decompress(data) == b'The quick brown fox jumps over the lazy dog'
 
-    r0 = -1
-    lwm = 0
-    done = False
 
-    # first byte verbatim
-    ud.destination += ud.source.read(1)
-
-    # main decompression loop
-    while not done:
-        if ap_getbit(ud):
-            if ap_getbit(ud):
-                if ap_getbit(ud):
-                    offs = 0
-
-                    for _ in range(4):
-                        offs = (offs << 1) + ap_getbit(ud)
-
-                    if offs:
-                        ud.destination.append(ud.destination[-offs])
-                    else:
-                        ud.destination.append(0x00)
-
-                    lwm = 0
-                else:
-                    offs = ord(ud.source.read(1))
-
-                    length = 2 + (offs & 0x0001)
-
-                    offs >>= 1
-
-                    if offs:
-                        for _ in range(length):
-                            ud.destination.append(ud.destination[-offs])
-                    else:
-                        done = True
-
-                    r0 = offs
-                    lwm = 1
-            else:
-                offs = ap_getgamma(ud)
-
-                if lwm == 0 and offs == 2:
-                    offs = r0
-
-                    length = ap_getgamma(ud)
-
-                    for _ in range(length):
-                        ud.destination.append(ud.destination[-offs])
-                else:
-                    if lwm == 0:
-                        offs -= 3
-                    else:
-                        offs -= 2
-
-                    offs <<= 8
-                    offs += ord(ud.source.read(1))
-
-                    length = ap_getgamma(ud)
-
-                    if offs >= 32000:
-                        length += 1
-                    if offs >= 1280:
-                        length += 1
-                    if offs < 128:
-                        length += 2
-
-                    for _ in range(length):
-                        ud.destination.append(ud.destination[-offs])
-
-                    r0 = offs
-
-                lwm = 1
-        else:
-            ud.destination += ud.source.read(1)
-            lwm = 0
-
-    return ud.destination
+if __name__ == '__main__':
+    main()

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -39,7 +39,7 @@ class APLib(object):
 
         return bit
 
-    def getgamma(self):
+    def getgamma(self) -> int:
         result = 1
 
         # input gamma2-encoded bits

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -133,35 +133,6 @@ class APLib(object):
     def pack(self):
         raise NotImplementedError
 
-
-def decompress(data, strict=False):
-    packed_size = None
-    packed_crc = None
-    orig_size = None
-    orig_crc = None
-
-    if data.startswith(b'AP32') and len(data) >= 24:
-        # data has an aPLib header
-        header_size, packed_size, packed_crc, orig_size, orig_crc = struct.unpack_from('=IIIII', data, 4)
-        data = data[header_size : header_size + packed_size]
-
-    if strict:
-        if packed_size is not None and packed_size != len(data):
-            raise RuntimeError('Packed data size is incorrect')
-        if packed_crc is not None and packed_crc != crc32(data):
-            raise RuntimeError('Packed data checksum is incorrect')
-
-    result = APLib(data, strict=strict).depack()
-
-    if strict:
-        if orig_size is not None and orig_size != len(result):
-            raise RuntimeError('Unpacked data size is incorrect')
-        if orig_crc is not None and orig_crc != crc32(result):
-            raise RuntimeError('Unpacked data checksum is incorrect')
-
-    return result
-
-
 def main():
     # self-test
     data = b'T\x00he quick\xecb\x0erown\xcef\xaex\x80jumps\xed\xe4veur`t?lazy\xead\xfeg\xc0\x00'

--- a/malduck/compression/components/aplib.py
+++ b/malduck/compression/components/aplib.py
@@ -131,6 +131,7 @@ class APLib(object):
     def pack(self):
         raise NotImplementedError
 
+
 def main():
     # self-test
     data = b"T\x00he quick\xecb\x0erown\xcef\xaex\x80jumps\xed\xe4veur`t?lazy\xead\xfeg\xc0\x00"

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -7,7 +7,6 @@ import pytest
 from malduck import aplib, gzip, base64, lznt1
 
 
-@pytest.mark.skipif("sys.platform == 'darwin'")
 def test_aplib():
     assert aplib(
         base64("QVAzMhgAAAANAAAAvJpimwsAAACFEUoNaDhlbI5vIHducuxkAA==")
@@ -28,12 +27,6 @@ QacB19//yAF9ff/8hwHX3//IAX19//yHAdff/8gBfX3//IcB19//yAF9ff/
     assert (
         aplib(b'T\x00he quick\xecb\x0erown\xcef\xaex\x80jumps\xed\xe4veur`t?lazy\xead\xfeg\xc0\x00') ==
         b'The quick brown fox jumps over the lazy dog')
-
-
-@pytest.mark.skipif("sys.platform != 'darwin'")
-def test_aplib_macos():
-    with pytest.raises(RuntimeError):
-        assert aplib(b"hello world")
 
 
 def test_gzip():

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -12,7 +12,6 @@ def test_aplib():
         base64("QVAzMhgAAAANAAAAvJpimwsAAACFEUoNaDhlbI5vIHducuxkAA==")
     ) == b"hello world"
     assert aplib(base64("aDhlbI5vIHducuxkAA==")) == b"hello world"
-
     assert aplib(base64("""
 QVAzMhgAAABGAAAAf+p8HwEAEAA5iu7QQacB19//yAF9ff/8hwHX3//IAX19//yHAdff/8gBfX3/
 /IcB19//yAF9ff/8hwHX3//IAX19//yHAdff/8gBXXf/2QqAAA==
@@ -21,9 +20,6 @@ QVAzMhgAAABGAAAAf+p8HwEAEAA5iu7QQacB19//yAF9ff/8hwHX3//IAX19//yHAdff/8gBfX3/
 QacB19//yAF9ff/8hwHX3//IAX19//yHAdff/8gBfX3//IcB19//yAF9ff/
 8hwHX3//IAX19//yH\nAdff/8gBXXf/2QqAAA==
 """)) == b"A"*1024*1024 + b"\n"
-
-    assert aplib(b"helloworld") is None
-    assert aplib(b"") is None
     assert (
         aplib(b'T\x00he quick\xecb\x0erown\xcef\xaex\x80jumps\xed\xe4veur`t?lazy\xead\xfeg\xc0\x00') ==
         b'The quick brown fox jumps over the lazy dog')


### PR DESCRIPTION
Using the function malduck.aplib() returned a None object.

We can see that running the tests:
![image](https://user-images.githubusercontent.com/7660940/128770334-fdeb3fcb-1585-47d4-bd89-a51f13d11fd0.png)


After the fixes in this PR the tests on compression are passed:
![image](https://user-images.githubusercontent.com/7660940/128769900-43b82c97-a8aa-45e6-a681-18a4c6aa0dc6.png)
