### PR TITLE
Add PE resource extraction

### DIFF
--- a/malduck/pe.py
+++ b/malduck/pe.py
@@ -341,9 +341,7 @@ class PE(object):
 
         for e1, e2, e3 in self.iterate_resources():
             if compare(e1, e2, e3):
-                yield self.pe.get_data(
-                    e3.data.struct.OffsetToData, e3.data.struct.Size
-                )
+                yield self.pe.get_data(e3.data.struct.OffsetToData, e3.data.struct.Size)
 
     def resource(self, name: Union[int, str, bytes]) -> Optional[bytes]:
         """


### PR DESCRIPTION
This PR adds a new cli option `resources` that collects PE resources from the input files and puts them in the destination folder:

```shell
malduck
Usage: malduck [OPTIONS] COMMAND [ARGS]...

Options:
  -l, --log-level TEXT         Set logging level for commands: critical,
                               error, warning (default), info, debug

  -v, --verbose / -q, --quiet  Verbose mode (shortcut for '--log-level debug')
                               / quiet mode ('--log-level error')

  --version                    Show the version and exit.
  --help                       Show this message and exit.

Commands:
  extract    Extract static configuration from dumps
  fixpe      Fix dumped PE file into the correct form
  resources  Extract PE resources from an EXE into a directory
```

```shell
malduck resources MBCrackme.exe  out
Found resource 3-1 (1128 bytes)
Found resource 3-2 (2440 bytes)
Found resource 3-3 (4264 bytes)
Found resource 3-4 (9640 bytes)
Found resource 3-5 (16936 bytes)
Found resource 14-32512 (76 bytes)
Found resource 16-1 (796 bytes)
Found resource 24-1 (490 bytes)
```
