### PR TITLE
Use lint-python v2 and bump Python to 3.8

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Lint and test on Python 3.6
+name: Lint and test on Python 3.7
 
 on:
   push:
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-            python-version: 3.6
+            python-version: 3.7
       - run: pip install .
       - run: pip install pytest==5.4.1
       - name: Test with pytest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Lint and test on Python 3.7
+name: Lint and test on Python 3.8
 
 on:
   push:
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-            python-version: 3.7
+            python-version: 3.8
       - run: pip install .
       - run: pip install pytest==5.4.1
       - name: Test with pytest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,11 +13,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: CERT-Polska/lint-python-action@v1
+      - uses: CERT-Polska/lint-python-action@v2
         with:
           source: malduck/
-          python-version: 3.6
-          extra-requirements: "mypy-extensions==0.4.3"
   test:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,7 @@ force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 88
+
+[tool.lint-python]
+lint-version = "2"
+source = "malduck/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ max-line-length = 88
 exclude = tests/*
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 
 [mypy-capstone.*]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ max-line-length = 88
 exclude = tests/*
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 
 [mypy-capstone.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
         "Programming Language :: Python :: 3",
         "Operating System :: POSIX :: Linux",
     ],
-    python_requires='>=3.7'
+    python_requires='>=3.8'
 )

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
         "Programming Language :: Python :: 3",
         "Operating System :: POSIX :: Linux",
     ],
-    python_requires='>=3.6'
+    python_requires='>=3.7'
 )


### PR DESCRIPTION
Python 3.6 is abandoned and is no longer available for setup in CI