### PR TITLE
Pin yara-python v4.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pefile>=2022.5.30
 pyelftools
 pycryptodomex>=3.8.2
 capstone>=4.0.1
-yara-python
+yara-python==4.2.3
 typing-extensions>=3.7.4.2
 cryptography>=3.1
 dnfile==0.11.0


### PR DESCRIPTION
In version v4.2.3 of yara-python accessing `strings` of a `yara.Match` object returns list of tuples of the form `(<offset>,<identifier>,<data>)` as seen in [docs](https://yara.readthedocs.io/en/v4.2.3/yarapython.html#yara.Match.strings).  However, in new [v4.3.0](https://yara.readthedocs.io/en/v4.3.0/yarapython.html#yara.Match.strings) they've abstracted it to return `List[StringMatch]`, where `StringMatch` itself also has abstracted `StringMatchInstance` member.

Shouldn't be too hard to refactor, but in the meantime maybe it's best to pin