### PR TITLE
Remove typing cast that slowed the working of integer types

### DIFF
--- a/malduck/ints.py
+++ b/malduck/ints.py
@@ -166,7 +166,7 @@ class IntType(int, IntTypeBase, metaclass=MetaIntType):
         value = int(value) & cls.mask
         if cls.signed:
             value |= -(value & cls.invert_mask)
-        return int.__new__(cls, value)
+        return int.__new__(cls, value)  # type: ignore
 
     def __add__(self, other: Any) -> "IntType":
         res = super().__add__(other)

--- a/malduck/ints.py
+++ b/malduck/ints.py
@@ -166,8 +166,7 @@ class IntType(int, IntTypeBase, metaclass=MetaIntType):
         value = int(value) & cls.mask
         if cls.signed:
             value |= -(value & cls.invert_mask)
-        construct = cast(Callable[[MetaIntType, Any], IntType], int.__new__)
-        return construct(cls, value)
+        return int.__new__(cls, value)
 
     def __add__(self, other: Any) -> "IntType":
         res = super().__add__(other)

--- a/malduck/ints.py
+++ b/malduck/ints.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from struct import error, pack, unpack_from
-from typing import Any, Callable, Generic, Iterator, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Generic, Iterator, Tuple, Type, TypeVar, Union
 
 from .bits import rol
 


### PR DESCRIPTION
Turns out that they are not completely free  ¯\\_(ツ)_/¯

`8.287 seconds` -> `3.863 seconds`

Should somewhat help with #90 
