### PR TITLE
#92 Ability to Add Files to Extraction

### DIFF
--- a/malduck/extractor/extract_manager.py
+++ b/malduck/extractor/extract_manager.py
@@ -291,7 +291,7 @@ class ProcmemExtractManager:
         self.globals: Dict[str, Any] = {}
         self.parent = parent  #: Bound ExtractManager instance
         self.family = None  #: Matched family
-        self.files = {}
+        self.files: Dict[str, Dict] = {}
 
     def on_extractor_error(
         self, exc: Exception, extractor: Extractor, method_name: str

--- a/malduck/extractor/extractor.py
+++ b/malduck/extractor/extractor.py
@@ -1,8 +1,8 @@
 import functools
 import inspect
 import logging
-from typing import List, cast
 from hashlib import sha256
+from typing import List, cast
 
 from ..procmem import ProcessMemory, ProcessMemoryELF, ProcessMemoryPE
 
@@ -354,13 +354,13 @@ class Extractor:
         """
         return self.parent.push_config(config, self)
 
-    def push_file(self, data: bytes, filename=''):
+    def push_file(self, data: bytes, filename=""):
         """
         Push file to files object
         """
         self.parent.files[sha256(data).hexdigest()] = {
-            'filename': filename,
-            'data': data
+            "filename": filename,
+            "data": data,
         }
 
     @property


### PR DESCRIPTION
Based on #92, These changes allow us to not only extract configuration information from malware but also additional files that we may have extracted statically. This is not only great for static unpacking, but also other binary data you may wish to extract for analysis or put back into the karon queue for processing.

```python
from malduck import Extractor
from pprint import pprint
e = Extractor(parent=None)
e.push_file(b'\x00'*4, filename='example.bin')
pprint(e.files)
{'6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d': {'data': b'\x00',
                                                                      'filename': 'hello.bin'}}
```

The files object is a sha256 hash  uniquely representing the file then the data and an optional filename.