### PR TITLE
Specify build os in readthedoc config file

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -17,3 +17,8 @@ python:
     - requirements: docs/requirements.txt
     - method: setuptools
       path: .
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"


### PR DESCRIPTION
As per https://blog.readthedocs.com/use-build-os-config/