### PR TITLE
Include image=True binaries in load_binaries_from_memory

### DIFF
--- a/malduck/extractor/extract_manager.py
+++ b/malduck/extractor/extract_manager.py
@@ -214,9 +214,6 @@ class ExtractManager:
         family = self._extract_procmem(p, matches)
         for binary in binaries:
             family = self._extract_procmem(binary, matches) or family
-            binary_image = binary.image
-            if binary_image:
-                family = self._extract_procmem(binary_image, matches) or family
         return family
 
     @property

--- a/malduck/procmem/binmem.py
+++ b/malduck/procmem/binmem.py
@@ -71,6 +71,12 @@ class ProcessMemoryBinary(ProcessMemory, metaclass=ABCMeta):
         """
         Looks for binaries in ProcessMemory object and yields specialized ProcessMemoryBinary objects
         :param procmem: ProcessMemory object to search
+
+        .. versionchanged:: 4.4.0
+
+            In addition to image=False binaries, it also returns image=True versions.
+            In previous versions it was done by extractor, so it was working only
+            if memory-aligned version was also "valid".
         """
         if cls.__magic__ is None:
             raise NotImplementedError()

--- a/malduck/procmem/binmem.py
+++ b/malduck/procmem/binmem.py
@@ -78,8 +78,8 @@ class ProcessMemoryBinary(ProcessMemory, metaclass=ABCMeta):
             binary_procmem_dmp = cls.from_memory(procmem, base=binary_va)
             if binary_procmem_dmp.is_valid():
                 yield binary_procmem_dmp
-            binary_procmem_img = cls.from_memory(procmem, base=binary_va, image=True)
-            if binary_procmem_img.is_valid():
+            binary_procmem_img = binary_procmem_dmp.image
+            if binary_procmem_img and binary_procmem_img.is_valid():
                 yield binary_procmem_img
 
     @abstractmethod

--- a/malduck/procmem/binmem.py
+++ b/malduck/procmem/binmem.py
@@ -75,9 +75,12 @@ class ProcessMemoryBinary(ProcessMemory, metaclass=ABCMeta):
         if cls.__magic__ is None:
             raise NotImplementedError()
         for binary_va in procmem.findv(cls.__magic__):
-            binary_procmem = cls.from_memory(procmem, base=binary_va)
-            if binary_procmem.is_valid():
-                yield binary_procmem
+            binary_procmem_dmp = cls.from_memory(procmem, base=binary_va)
+            if binary_procmem_dmp.is_valid():
+                yield binary_procmem_dmp
+            binary_procmem_img = cls.from_memory(procmem, base=binary_va, image=True)
+            if binary_procmem_img.is_valid():
+                yield binary_procmem_img
 
     @abstractmethod
     def is_image_loaded_as_memdump(self) -> bool:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,6 @@ ignore_missing_imports = True
 
 [mypy-ida_bytes.*]
 ignore_missing_imports = True
+
+[mypy-dnfile.*]
+ignore_missing_imports = True


### PR DESCRIPTION
In addition to image=False binaries, it also returns image=True versions.
In previous versions it was done by extractor, so it was working only if memory-aligned version was also "valid".