### PR TITLE
Bump lint-python and fix RTD

### DIFF
--- a/malduck/crypto/aes.py
+++ b/malduck/crypto/aes.py
@@ -19,6 +19,7 @@ class PlaintextKeyBlob(BaseBlob):
 
     .. seealso:: :class:`malduck.crypto.BLOBHEADER`
     """
+
     types = {
         16: "AES-128",
         24: "AES-192",

--- a/malduck/crypto/winhdr.py
+++ b/malduck/crypto/winhdr.py
@@ -18,6 +18,7 @@ class BLOBHEADER(Structure):
         BLOBHEADER structure description (Microsoft Docs):
         https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-publickeystruc
     """
+
     _pack_ = 1
     _fields_ = [
         ("bType", UInt8),

--- a/malduck/procmem/binmem.py
+++ b/malduck/procmem/binmem.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Iterator, List, Optional, Type, TypeVar
+
 from typing_extensions import Self
 
 from .procmem import ProcessMemory, ProcessMemoryBuffer

--- a/malduck/procmem/binmem.py
+++ b/malduck/procmem/binmem.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Iterator, List, Optional, Type, TypeVar
+from typing_extensions import Self
 
 from .procmem import ProcessMemory, ProcessMemoryBuffer
 from .region import Region
@@ -18,7 +19,7 @@ class ProcessMemoryBinary(ProcessMemory, metaclass=ABCMeta):
     __magic__: Optional[bytes] = None
 
     def __init__(
-        self: T,
+        self,
         buf: ProcessMemoryBuffer,
         base: int = 0,
         regions: Optional[List[Region]] = None,
@@ -29,7 +30,7 @@ class ProcessMemoryBinary(ProcessMemory, metaclass=ABCMeta):
         if detect_image:
             image = self.is_image_loaded_as_memdump()
         self.is_image = image
-        self._image: Optional[T] = None
+        self._image: Optional[Self] = None
         if image:
             self._reload_as_image()
 
@@ -41,7 +42,7 @@ class ProcessMemoryBinary(ProcessMemory, metaclass=ABCMeta):
         raise NotImplementedError()
 
     @property
-    def image(self: T) -> Optional[T]:
+    def image(self) -> Optional[Self]:
         """
         Returns ProcessMemory object loaded with image=True or None if can't be loaded or is loaded as image yet
         """
@@ -49,7 +50,7 @@ class ProcessMemoryBinary(ProcessMemory, metaclass=ABCMeta):
             return None
         try:
             if not self._image:
-                self._image = self.__class__.from_memory(self, image=True)
+                self._image = self.from_memory(self, image=True)
             return self._image
         except Exception:
             import traceback

--- a/malduck/procmem/procmem.pyi
+++ b/malduck/procmem/procmem.pyi
@@ -71,7 +71,7 @@ class ProcessMemory:
     def from_file(cls: Type[T], filename: str, **kwargs) -> T: ...
     @classmethod
     def from_memory(
-        cls: Type[T], memory: "ProcessMemory", base: int = None, **kwargs
+        cls: Type[T], memory: "ProcessMemory", base: Optional[int] = None, **kwargs
     ) -> T: ...
     @property
     def length(self) -> int: ...
@@ -228,8 +228,8 @@ class ProcessMemory:
     ) -> Iterator[Instruction]: ...
     def extract(
         self,
-        modules: ExtractorModules = None,
-        extract_manager: ExtractManager = None,
+        modules: Optional[ExtractorModules] = None,
+        extract_manager: Optional[ExtractManager] = None,
     ) -> Optional[List[Dict[str, Any]]]: ...
     # yarap(ruleset)
     # yarap(ruleset, offset)

--- a/malduck/yara.pyi
+++ b/malduck/yara.pyi
@@ -101,6 +101,7 @@ class YaraRulesetMatch(_Mapper["YaraRuleMatch"]):
         offset_mapper: Optional[OffsetMapper] = None,
     ) -> None:
         super().__init__(elements={})
+
     def _map_matches(
         self, matches: List[YaraRulesMatch], offset_mapper: Optional[OffsetMapper]
     ) -> Dict[str, "YaraRuleMatch"]: ...
@@ -116,6 +117,7 @@ class YaraRulesetOffsets(_Mapper["YaraRuleOffsets"]):
     _matches: YaraRulesetMatch
     def __init__(self, matches: YaraRulesetMatch) -> None:
         super().__init__(elements={})
+
     def remap(
         self, offset_mapper: Optional[OffsetMapper] = None
     ) -> "YaraRulesetOffsets": ...
@@ -137,6 +139,7 @@ class YaraRuleMatch(_Mapper[List[YaraStringMatch]]):
         tags: List[str],
     ) -> None:
         super().__init__({})
+
     def get_offsets(self, string) -> List[int]: ...
 
 class YaraRuleOffsets(_Mapper[List[int]]):

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -15,7 +15,7 @@ formats: all
 python:
   install:
     - requirements: docs/requirements.txt
-    - method: setuptools
+    - method: pip
       path: .
 
 build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pyelftools
 pycryptodomex>=3.8.2
 capstone>=4.0.1
 yara-python
-typing-extensions>=3.7.4.2
+typing-extensions>=4.0.0
 cryptography>=3.1
 dnfile>=0.15.0


### PR DESCRIPTION
- Bumped lint-python and used newer liinter/formatter versions
- Bumped typing-extensions to use Self type and fix generic self pattern that was misunderstood by mypy in binmem
- Another version of fix for RTD (https://github.com/CERT-Polska/malduck/issues/127)